### PR TITLE
deployment: multi-arch main image

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -41,5 +41,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 # build
 RUN make
 
-FROM gcr.io/distroless/base:debug
+FROM gcr.io/distroless/base:debug-${TARGETARCH:-amd64}
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/cli/bin/* /bin/
 ENTRYPOINT [ "/bin/pomerium-cli" ]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,4 @@
-ARG ARCH
-
-FROM gcr.io/distroless/static:latest-${ARCH}
+FROM gcr.io/distroless/static:latest-${TARGETARCH:-amd64}
 WORKDIR /pomerium
 COPY pomerium* /bin/
 ENTRYPOINT [ "/bin/pomerium-cli" ]

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -130,7 +130,7 @@ dockers:
     dockerfile: Dockerfile.release
     build_flag_templates:
       - "--pull"
-      - "--build-arg=ARCH=amd64"
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -145,7 +145,7 @@ dockers:
     dockerfile: Dockerfile.release
     build_flag_templates:
       - "--pull"
-      - "--build-arg=ARCH=arm64"
+      - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"


### PR DESCRIPTION
## Summary

Ensure multi-arch release is consistent with other projects and add in a multiarch rolling `main` image.


## Related issues

https://github.com/pomerium/pomerium/pull/2925
https://github.com/pomerium/ingress-controller/pull/120

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
