### PR TITLE
ci: fix lint during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 
 # build
-RUN make
+RUN make build
 
 FROM gcr.io/distroless/base:debug
 WORKDIR /pomerium

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test: ## test everything
 
 .PHONY: lint
 lint: ## run go mod tidy
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint --timeout=120s run ./...
 
 .PHONY: tidy
 tidy: ## run go mod tidy


### PR DESCRIPTION
## Summary

We're starting to timeout when doing a cold lint run inside our docker image.

- add a timeout
- avoid linting during image build since it can take a while

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
