### PR TITLE
deployment: fix multiarch release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,11 @@ jobs:
         with:
           go-version: 1.17.x
 
-      - name: Set up Docker
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
       - uses: azure/docker-login@v1
         with:
@@ -35,7 +38,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.184.0
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -128,6 +128,7 @@ dockers:
   - image_templates:
       - "pomerium/cli:amd64-{{ .Tag }}"
     dockerfile: Dockerfile.release
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
@@ -143,6 +144,7 @@ dockers:
     image_templates:
       - "pomerium/cli:arm64v8-{{ .Tag }}"
     dockerfile: Dockerfile.release
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"


### PR DESCRIPTION
## Summary

Ensure we're using docker buildx for releases so that `TARGETARCH` is filled in properly.

## Related issues

#27 


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
