### PR TITLE
ci: set explicit token permissions

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,4 +1,6 @@
 name: Backport
+permissions:
+  contents: read
 on:
   pull_request_target:
     types:

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -1,4 +1,6 @@
 name: Docker Main
+permissions:
+  contents: read
 on:
   push:
     branches:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 name: Release
-
+permissions:
+  contents: read
 on:
   release:
     types:
@@ -7,6 +8,10 @@ on:
 
 jobs:
   goreleaser:
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: read
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,10 +1,12 @@
+name: Test
+permissions:
+  contents: read
 on:
   push:
     branches:
       - main
   pull_request:
 
-name: Test
 jobs:
   test:
     strategy:


### PR DESCRIPTION
## Summary

Adopt https://github.com/ossf/scorecard standards for default github token permissions.

## Related issues

https://github.com/pomerium/internal/issues/813


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
