### PR TITLE
fix save after import

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@release
         with:

--- a/api/config_server.go
+++ b/api/config_server.go
@@ -121,6 +121,11 @@ func (s *server) Import(_ context.Context, req *pb.ImportRequest) (*pb.ImportRes
 	if err := importRecords(s.config, req); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+
+	if err := s.config.save(s.ConfigProvider); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	return &pb.ImportResponse{}, nil
 }
 


### PR DESCRIPTION
## Summary

Import only stored in memory and didn't flush config to disk, that resulted in loss of records if you 
quit immediatelly after import. 

## Related issues
Fixes https://github.com/pomerium/internal/issues/868

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
