### PR TITLE
tcptunnel: on 503, keep cached JWT

### DIFF
--- a/tcptunnel/tcptunnel.go
+++ b/tcptunnel/tcptunnel.go
@@ -154,6 +154,9 @@ func (tun *Tunnel) run(ctx context.Context, evt TunnelEvents, local io.ReadWrite
 	}()
 	switch res.StatusCode {
 	case http.StatusOK:
+	case http.StatusServiceUnavailable:
+		// don't delete the JWT if we get a service unavailable
+		return fmt.Errorf("invalid http response code: %s", res.Status)
 	case http.StatusMovedPermanently,
 		http.StatusFound,
 		http.StatusTemporaryRedirect,


### PR DESCRIPTION
## Summary
On a 503 error, keep the cached JWT instead of deleting it.

## Related issues
Fixes https://github.com/pomerium/cli/issues/17


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
