### PR TITLE
go: upgrade to go 1.18

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@f717b5ecd4534d3c4df4ce9b5c1c2214f0f7cd06
         with:
           app_id: ${{ secrets.BACKPORT_APP_APPID }}
           private_key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
 
       - name: Backport
-        uses: tibdex/backport@v1
+        uses: tibdex/backport@e2ffd4c5a70730dfd19046859dfaf366e3de6466
         with:
           github_token: ${{ steps.generate_token.outputs.token }}
           title_template: "{{originalTitle}}"

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -15,22 +15,22 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
         with:
           images: pomerium/cli
           tags: |
@@ -38,7 +38,7 @@ jobs:
             type=ref,event=branch
 
       - name: Docker Publish - Main
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1cb9d22b932e4832bb29793b7777ec860fc1cde0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,29 +19,29 @@ jobs:
       tag: ${{ steps.tagName.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Unshallow
         run: git fetch --prune --unshallow
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
 
-      - uses: azure/docker-login@v1
+      - uses: azure/docker-login@81744f9799e7eaa418697cb168452a2882ae844a
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef
         with:
           args: release
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request: null
 
 jobs:
   test:
@@ -15,16 +15,16 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: ${{ matrix.go-version }}
       - name: set env vars
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
       - name: cache go binaries
-        uses: actions/cache@v3
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
         id: cache-go-bin
         with:
           path: ~/go/bin
@@ -39,18 +39,20 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: 1.18.x
       - uses: actions/setup-python@c4e89fac7e8767b327bbad6cb4d859eda999cf08
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@release
+      - uses: pre-commit/action@cf04e2f8169912b1d83e0821974f3a1af8b3c873
         with:
-          extra_args: --show-diff-on-failure --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
+          extra_args: --show-diff-on-failure --from-ref ${{
+            github.event.pull_request.base.sha }} --to-ref ${{
+            github.event.pull_request.head.sha }}
         env:
           SKIP: lint
 
@@ -63,13 +65,13 @@ jobs:
     needs:
       - test
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: 1.18.x
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: FOSSA Scan
-        uses: fossa-contrib/fossa-action@v1
+        uses: fossa-contrib/fossa-action@6cffaa064112e1cf9b5798c6224f9487dc1ec316
         with:
           fossa-api-key: 18f4ef488f514d06874b75f5809cea93

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,11 @@ go 1.18
 require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/client9/misspell v0.3.4
+	github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94
+	github.com/getsentry/sentry-go v0.13.0
+	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-jose/go-jose/v3 v3.0.0
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golangci/golangci-lint v1.47.2
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
@@ -19,13 +23,6 @@ require (
 	google.golang.org/grpc v1.48.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
 	google.golang.org/protobuf v1.28.1
-)
-
-require (
-	github.com/elazarl/goproxy v0.0.0-20220417044921-416226498f94
-	github.com/getsentry/sentry-go v0.13.0
-	github.com/go-chi/chi/v5 v5.0.7
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 )
 
 require (


### PR DESCRIPTION
## Summary
Upgrade to go 1.18.

- https://github.com/pomerium/internal/issues/932