### PR TITLE
tcp: add extended tcp support

### DIFF
--- a/tcptunnel/urls.go
+++ b/tcptunnel/urls.go
@@ -1,0 +1,60 @@
+package tcptunnel
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+func ParseURLs(destination string, pomeriumURL string) (destinationAddr string, proxyURL *url.URL, err error) {
+	if strings.Contains(destination, "://") {
+		destinationURL, err := url.Parse(destination)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid destination")
+		}
+
+		paths := strings.Split(destinationURL.Path, "/")[1:]
+		if len(paths) == 0 {
+			destinationAddr = destinationURL.Host
+			proxyURL = &url.URL{
+				Scheme: strings.TrimPrefix(destinationURL.Scheme, "tcp+"),
+				Host:   destinationURL.Hostname(),
+			}
+		} else {
+			destinationAddr = paths[0]
+			proxyURL = &url.URL{
+				Scheme: strings.TrimPrefix(destinationURL.Scheme, "tcp+"),
+				Host:   destinationURL.Host,
+			}
+		}
+	} else if h, p, err := net.SplitHostPort(destination); err == nil {
+		destinationAddr = net.JoinHostPort(h, p)
+		proxyURL = &url.URL{
+			Scheme: "https",
+			Host:   h,
+		}
+	} else {
+		return "", nil, fmt.Errorf("invalid destination")
+	}
+
+	if pomeriumURL != "" {
+		proxyURL, err = url.Parse(pomeriumURL)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid pomerium url")
+		}
+		if proxyURL.Host == "" {
+			return "", nil, fmt.Errorf("invalid pomerium url")
+		}
+	}
+
+	if !strings.Contains(proxyURL.Host, ":") {
+		if proxyURL.Scheme == "https" {
+			proxyURL.Host = net.JoinHostPort(proxyURL.Host, "443")
+		} else {
+			proxyURL.Host = net.JoinHostPort(proxyURL.Host, "80")
+		}
+	}
+
+	return destinationAddr, proxyURL, nil
+}

--- a/tcptunnel/urls_test.go
+++ b/tcptunnel/urls_test.go
@@ -1,0 +1,53 @@
+package tcptunnel
+
+import (
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseURLs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name                     string
+		destination, pomeriumURL string
+		destinationAddr          string
+		proxyURL                 string
+		err                      error
+	}{
+		{"invalid destination", "", "", "", "", errors.New("invalid destination")},
+		{"host:port", "redis.example.com:6379", "", "redis.example.com:6379", "https://redis.example.com:443", nil},
+		{"https url", "tcp+https://redis.example.com:6379", "", "redis.example.com:6379", "https://redis.example.com:443", nil},
+		{"http url", "http://redis.example.com:6379", "", "redis.example.com:6379", "http://redis.example.com:80", nil},
+		{"https url path", "https://proxy.example.com/redis.example.com:6379", "", "redis.example.com:6379", "https://proxy.example.com:443", nil},
+		{"non standard port path", "https://proxy.example.com:8443/redis.example.com:6379", "", "redis.example.com:6379", "https://proxy.example.com:8443", nil},
+
+		{"invalid pomerium url", "redis.example.com:6379", "example.com:1234", "", "", errors.New("invalid pomerium url")},
+		{"pomerium url", "redis.example.com:6379", "https://proxy.example.com", "redis.example.com:6379", "https://proxy.example.com:443", nil},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var expectedProxyURL *url.URL
+			if tc.proxyURL != "" {
+				expectedProxyURL = must(url.Parse(tc.proxyURL))
+			}
+
+			destinationAddr, proxyURL, err := ParseURLs(tc.destination, tc.pomeriumURL)
+			assert.Equal(t, tc.destinationAddr, destinationAddr)
+			assert.Equal(t, expectedProxyURL, proxyURL)
+			assert.Equal(t, tc.err, err)
+		})
+	}
+}
+
+func must[T any](ret T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}


### PR DESCRIPTION
## Summary
Add extended TCP support so that in addition to:

```
pomerium-cli tcp redis.example.com:6379
```

You can also use:

```
pomerium-cli tcp tcp+https://proxy.example.com/redis.example.com:6379
```

The existing `pomerium-url` option also still works.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1201


## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
