### PR TITLE
fix delete

### DIFF
--- a/api/config_server.go
+++ b/api/config_server.go
@@ -64,6 +64,10 @@ func (s *server) Delete(_ context.Context, sel *pb.Selector) (*pb.DeleteRecordsR
 		}
 	}
 
+	if err := s.config.save(s.ConfigProvider); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
 	return &pb.DeleteRecordsResponse{}, nil
 }
 


### PR DESCRIPTION
## Summary

Fixes connection deletion that did not persist the change. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes https://github.com/pomerium/desktop-client/issues/175

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
