### PR TITLE
integrate with system cert store

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ clean: ## Cleanup any build binaries or packages.
 .PHONY: build
 build: ## Build everything.
 	@echo "==> $@"
-	@go build $(GO_LDFLAGS) -o $(BINDIR)/$(NAME) ./cmd/"$(NAME)"
+	@go build -tags "$(BUILDTAGS)" $(GO_LDFLAGS) -o $(BINDIR)/$(NAME) ./cmd/"$(NAME)"
 
 .PHONY: snapshot
 snapshot: ## Create release snapshot

--- a/certstore/certstore.go
+++ b/certstore/certstore.go
@@ -1,0 +1,3 @@
+// Package certstore handles loading client certificates and private keys from
+// an OS-specific certificate store.
+package certstore

--- a/certstore/certstore_darwin.go
+++ b/certstore/certstore_darwin.go
@@ -1,0 +1,24 @@
+//go:build darwin && cgo
+
+package certstore
+
+import (
+	"crypto/tls"
+
+	"github.com/pomerium/cli/third_party/ecpsigner/darwin/keychain"
+	"github.com/pomerium/cli/version"
+)
+
+var IsCertstoreSupported = true
+
+func init() {
+	version.Features = append(version.Features, "keychain")
+}
+
+func LoadCert(issuer string) (*tls.Certificate, error) {
+	cred, err := keychain.Cred(issuer)
+	if err != nil {
+		return nil, err
+	}
+	return toTLSCertificate(cred), nil
+}

--- a/certstore/certstore_stub.go
+++ b/certstore/certstore_stub.go
@@ -1,0 +1,14 @@
+//go:build !(cgo && (darwin || windows))
+
+package certstore
+
+import (
+	"crypto/tls"
+	"errors"
+)
+
+var IsCertstoreSupported = false
+
+func LoadCert(issuer string) (*tls.Certificate, error) {
+	return nil, errors.New("this build of pomerium-cli does not support this feature")
+}

--- a/certstore/certstore_windows.go
+++ b/certstore/certstore_windows.go
@@ -1,0 +1,29 @@
+//go:build windows && cgo
+
+package certstore
+
+import (
+	"crypto/tls"
+
+	"github.com/pomerium/cli/third_party/ecpsigner/windows/ncrypt"
+	"github.com/pomerium/cli/version"
+)
+
+var IsCertstoreSupported = true
+
+func init() {
+	version.Features = append(version.Features, "ncrypt")
+}
+
+func LoadCert(issuer string) (*tls.Certificate, error) {
+	// Try the MY store in both the CURRENT_USER and LOCAL_MACHINE locations.
+	cred, err := ncrypt.Cred(issuer, "MY", "current_user")
+	if err == nil {
+		return toTLSCertificate(cred), nil
+	}
+	cred, err = ncrypt.Cred(issuer, "MY", "local_machine")
+	if err == nil {
+		return toTLSCertificate(cred), nil
+	}
+	return nil, err
+}

--- a/certstore/credential.go
+++ b/certstore/credential.go
@@ -1,0 +1,20 @@
+//go:build cgo && (darwin || windows)
+
+package certstore
+
+import (
+	"crypto"
+	"crypto/tls"
+)
+
+type credential interface {
+	crypto.Signer
+	CertificateChain() [][]byte
+}
+
+func toTLSCertificate(cred credential) *tls.Certificate {
+	return &tls.Certificate{
+		Certificate: cred.CertificateChain(),
+		PrivateKey:  cred,
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,9 @@ var (
 	// BuildMeta specifies release type (dev,rc1,beta,etc)
 	BuildMeta = ""
 
+	// Features contains a list of supported features.
+	Features []string
+
 	runtimeVersion = runtime.Version()
 )
 
@@ -32,6 +35,13 @@ func FullVersion() string {
 	}
 	if GitCommit != "" {
 		sb.WriteString("+" + GitCommit)
+	}
+	if len(Features) > 0 {
+		sb.WriteString("\nFeatures:")
+		for _, f := range Features {
+			sb.WriteRune(' ')
+			sb.WriteString(f)
+		}
 	}
 	return sb.String()
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -11,26 +11,30 @@ func TestFullVersionVersion(t *testing.T) {
 		Version   string
 		GitCommit string
 		BuildMeta string
+		Features  []string
 
 		expected string
 	}{
-		{"", "", "", ""},
-		{"1.0.0", "", "", "1.0.0"},
-		{"1.0.0", "314501b", "", "1.0.0+314501b"},
-		{"1.0.0", "314501b", "dev", "1.0.0-dev+314501b"},
+		{"", "", "", nil, ""},
+		{"1.0.0", "", "", nil, "1.0.0"},
+		{"1.0.0", "314501b", "", nil, "1.0.0+314501b"},
+		{"1.0.0", "314501b", "dev", nil, "1.0.0-dev+314501b"},
+		{"1.0.0", "314501b", "dev", []string{"foo", "bar"}, "1.0.0-dev+314501b\nFeatures: foo bar"},
 	}
 	for _, tt := range tests {
 		Version = tt.Version
 		GitCommit = tt.GitCommit
 		BuildMeta = tt.BuildMeta
+		Features = tt.Features
 
 		if got := FullVersion(); got != tt.expected {
-			t.Errorf("expected (%s) got (%s) for Version(%s), GitCommit(%s) BuildMeta(%s)",
+			t.Errorf("expected (%s) got (%s) for Version(%s), GitCommit(%s) BuildMeta(%s) Features(%v)",
 				tt.expected,
 				got,
 				tt.Version,
 				tt.GitCommit,
-				tt.BuildMeta)
+				tt.BuildMeta,
+				tt.Features)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Add a new package `certstore` to provide a common interface for the macOS and Windows platform-specific trust store methods from the vendored `third_party/ecpsigner` code.

Add a new `--client-cert-issuer-cn` flag to the tcp command using this functionality. Register this flag only when the feature is supported.

Update the version output to add a new 'Features:' line to indicate whether pomerium-cli was compiled with support for this feature. Give the macOS integration the feature name 'keychain' and the Windows integration the feature name 'ncrypt'.

## Related issues

- https://github.com/pomerium/cli/issues/308

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
