### PR TITLE
replace ::set-output in release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,8 +52,8 @@ jobs:
         id: tagName
         run: |
           TAG=$(git describe --tags --exact-match)
-          echo ::set-output name=tag::${TAG}
-          echo ::set-output name=version::${TAG#v}
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
       - name: Install Cloudsmith CLI
         run: |
@@ -79,7 +79,7 @@ jobs:
         id: latestTag
         run: |
           LATEST_TAG=$(git tag | grep -vi 'rc' | sort --version-sort | tail -1)
-          echo "::set-output name=tag::${LATEST_TAG}"
+          echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
 
       - name: Publish latest tag
         if: "steps.latestTag.outputs.tag == steps.tagName.outputs.tag"


### PR DESCRIPTION
## Summary

Update the 'Release' GitHub Action workflow to replace the deprecated `::set-output` command with the newer `$GITHUB_OUTPUT` file mechanism.

## Related issues

- https://github.com/pomerium/internal/issues/1511

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
