### PR TITLE
release: build for macOS and Windows separately

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,22 +1,114 @@
 name: Release
 permissions:
-  contents: read
+  contents: write # in order to upload release assets
 on:
   release:
     types:
       - published
 
 jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      versionFlags: ${{ steps.flags.outputs.versionFlags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+
+      - name: Set build version metadata flags
+        id: flags
+        run: |
+          ldflags=(
+            "-X github.com/pomerium/cli/version.Version=${{ github.event.release.tag_name }}"
+            "-X github.com/pomerium/cli/version.GitCommit=$(git rev-parse --short HEAD)"
+            "-X github.com/pomerium/cli/version.BuildMeta=$(date +%s)"
+            "-X github.com/pomerium/cli/version.ProjectName=pomerium-cli"
+            "-X github.com/pomerium/cli/version.ProjectURL=https://www.pomerium.io"
+          )
+          echo "versionFlags=${ldflags[*]}" >> $GITHUB_OUTPUT
+
+  build-macos:
+    runs-on: macos-latest
+    needs: metadata
+    outputs:
+      checksums: ${{ steps.build.outputs.checksums }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+        with:
+          go-version: 1.20.x
+
+      - name: Build and archive
+        id: build
+        run: |
+          echo 'checksums<<EOF' >> $GITHUB_OUTPUT
+          for arch in amd64 arm64; do
+            mkdir -p bin/$arch
+            GOARCH=$arch CGO_ENABLED=1 go build -o bin/$arch \
+              -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
+              ./cmd/pomerium-cli
+            gtar czf pomerium-cli-darwin-$arch.tar.gz -C bin/$arch pomerium-cli
+            shasum -a 256 pomerium-cli-darwin-$arch.tar.gz >> $GITHUB_OUTPUT
+          done
+          echo EOF >> $GITHUB_OUTPUT
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" pomerium-cli-darwin-*.tar.gz
+
+  build-windows:
+    runs-on: windows-latest
+    needs: metadata
+    outputs:
+      checksums: ${{ steps.build.outputs.checksums }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
+        with:
+          go-version: 1.20.x
+
+      - name: Build and archive
+        id: build
+        shell: bash
+        run: |
+          echo 'checksums<<EOF' >> $GITHUB_OUTPUT
+          for arch in amd64 arm64; do
+            mkdir -p bin/$arch
+            GOARCH=$arch CGO_ENABLED=1 go build -o bin/$arch \
+              -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
+              ./cmd/pomerium-cli
+            zipfile="pomerium-cli-windows-$arch.zip"
+            powershell "Compress-Archive -Path bin\\$arch\\\* -DestinationPath $zipfile"
+            hash=$(powershell "(Get-FileHash $zipfile -Algorithm SHA256).Hash.ToLower()")
+            echo "$hash  $zipfile" >> $GITHUB_OUTPUT
+          done
+          echo EOF >> $GITHUB_OUTPUT
+
+      - name: Upload to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" pomerium-cli-windows-*.zip
+
   goreleaser:
     permissions:
       contents: write
       issues: read
       pull-requests: read
     runs-on: ubuntu-latest
+    needs: metadata
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     outputs:
       tag: ${{ steps.tagName.outputs.tag }}
+      checksums: ${{ steps.checksums.outputs.checksums }}
     steps:
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
@@ -45,8 +137,17 @@ jobs:
           version: v1.18.2
           args: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           APPARITOR_GITHUB_TOKEN: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+          VERSION_FLAGS: ${{ needs.metadata.outputs.versionFlags }}
+
+      - name: Compute checksums
+        id: checksums
+        working-directory: ./dist
+        run: |
+          echo 'checksums<<EOF' >> $GITHUB_OUTPUT
+          shasum -a 256 *.{tar.gz,deb,rpm} >> $GITHUB_OUTPUT
+          echo EOF >> $GITHUB_OUTPUT
 
       - name: Get tag name
         id: tagName
@@ -86,3 +187,17 @@ jobs:
         run: |
           docker manifest create -a pomerium/cli:latest pomerium/cli:amd64-${{ steps.tagName.outputs.tag }} pomerium/cli:arm64v8-${{ steps.tagName.outputs.tag }}
           docker manifest push pomerium/cli:latest
+
+  upload-checksums:
+    runs-on: ubuntu-latest
+    needs: [build-macos, build-windows, goreleaser]
+    steps:
+      - name: Upload checksums
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "${{ needs.build-macos.outputs.checksums }}" >> pomerium-cli_checksums.txt
+          echo "${{ needs.build-windows.outputs.checksums }}" >> pomerium-cli_checksums.txt
+          echo "${{ needs.goreleaser.outputs.checksums }}" >> pomerium-cli_checksums.txt
+          gh release upload "${{ github.event.release.tag_name }}" pomerium-cli_checksums.txt

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -25,8 +25,6 @@ builds:
       - arm64
     goos:
       - linux
-      - darwin
-      - windows
       - freebsd
     goarm:
       - "6"
@@ -38,12 +36,7 @@ builds:
         goarch: arm
 
     ldflags:
-      - -s -w
-      - -X github.com/pomerium/cli/version.Version={{.Version}}
-      - -X github.com/pomerium/cli/version.GitCommit={{.ShortCommit}}
-      - -X github.com/pomerium/cli/version.BuildMeta={{.Timestamp}}
-      - -X github.com/pomerium/cli/version.ProjectName=pomerium-cli
-      - -X github.com/pomerium/cli/version.ProjectURL=https://www.pomerium.io
+      - "-s -w {{ .Env.VERSION_FLAGS }}"
 
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
@@ -57,7 +50,7 @@ archives:
         format: zip
 
 checksum:
-  name_template: "{{ .ProjectName }}_checksums.txt"
+  disable: true
 
 snapshot:
   name_template: "{{ .Version }}+next+{{ .ShortCommit }}"


### PR DESCRIPTION
## Summary

Update the GitHub Actions 'Release' workflow to build for macOS and Windows within separate jobs, so we can perform the macOS builds on a macOS runner and the Windows builds on a Windows runner. This is in preparation for building against OS-specific libraries (with cgo).

Add a separate job at the beginning for setting version flags to be shared across all three build jobs, and a separate job at the end for combining all of the release asset checksums into one file.

## Related issues

In preparation for #308.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
