### PR TITLE
vendor internal/signer from enterprise-certificate-proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,9 @@ require (
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/crypto v0.12.0
 	golang.org/x/sync v0.3.0
+	golang.org/x/sys v0.11.0
 	google.golang.org/grpc v1.57.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.31.0
@@ -194,12 +196,10 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
 	golang.org/x/exp/typeparams v0.0.0-20230307190834-24139beb5833 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect
 	golang.org/x/tools v0.12.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230706204954-ccb25ca9f130 // indirect

--- a/third_party/ecpsigner/LICENSE
+++ b/third_party/ecpsigner/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/ecpsigner/darwin/keychain/keychain.go
+++ b/third_party/ecpsigner/darwin/keychain/keychain.go
@@ -1,0 +1,407 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin && cgo
+// +build darwin,cgo
+
+// Package keychain contains functions for retrieving certificates from the Darwin Keychain.
+package keychain
+
+/*
+#cgo CFLAGS: -mmacosx-version-min=10.12
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"runtime"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+// Maps for translating from crypto.Hash to SecKeyAlgorithm.
+// https://developer.apple.com/documentation/security/seckeyalgorithm
+var (
+	ecdsaAlgorithms = map[crypto.Hash]C.CFStringRef{
+		crypto.SHA256: C.kSecKeyAlgorithmECDSASignatureDigestX962SHA256,
+		crypto.SHA384: C.kSecKeyAlgorithmECDSASignatureDigestX962SHA384,
+		crypto.SHA512: C.kSecKeyAlgorithmECDSASignatureDigestX962SHA512,
+	}
+	rsaPKCS1v15Algorithms = map[crypto.Hash]C.CFStringRef{
+		crypto.SHA256: C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256,
+		crypto.SHA384: C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384,
+		crypto.SHA512: C.kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512,
+	}
+	rsaPSSAlgorithms = map[crypto.Hash]C.CFStringRef{
+		crypto.SHA256: C.kSecKeyAlgorithmRSASignatureDigestPSSSHA256,
+		crypto.SHA384: C.kSecKeyAlgorithmRSASignatureDigestPSSSHA384,
+		crypto.SHA512: C.kSecKeyAlgorithmRSASignatureDigestPSSSHA512,
+	}
+)
+
+// cfStringToString returns a Go string given a CFString.
+func cfStringToString(cfStr C.CFStringRef) string {
+	s := C.CFStringGetCStringPtr(cfStr, C.kCFStringEncodingUTF8)
+	if s != nil {
+		return C.GoString(s)
+	}
+	glyphLength := C.CFStringGetLength(cfStr) + 1
+	utf8Length := C.CFStringGetMaximumSizeForEncoding(glyphLength, C.kCFStringEncodingUTF8)
+	if s = (*C.char)(C.malloc(C.size_t(utf8Length))); s == nil {
+		panic("unable to allocate memory")
+	}
+	defer C.free(unsafe.Pointer(s))
+	if C.CFStringGetCString(cfStr, s, utf8Length, C.kCFStringEncodingUTF8) == 0 {
+		panic("unable to convert cfStringref to string")
+	}
+	return C.GoString(s)
+}
+
+func cfRelease(x unsafe.Pointer) {
+	C.CFRelease(C.CFTypeRef(x))
+}
+
+// cfError is an error type that owns a CFErrorRef, and obtains the error string
+// by using CFErrorCopyDescription.
+type cfError struct {
+	e C.CFErrorRef
+}
+
+// cfErrorFromRef converts a C.CFErrorRef to a cfError, taking ownership of the
+// reference and releasing when the value is finalized.
+func cfErrorFromRef(cfErr C.CFErrorRef) *cfError {
+	if cfErr == 0 {
+		return nil
+	}
+	c := &cfError{e: cfErr}
+	runtime.SetFinalizer(c, func(x interface{}) {
+		C.CFRelease(C.CFTypeRef(x.(*cfError).e))
+	})
+	return c
+}
+
+func (e *cfError) Error() string {
+	s := C.CFErrorCopyDescription(C.CFErrorRef(e.e))
+	defer C.CFRelease(C.CFTypeRef(s))
+	return cfStringToString(s)
+}
+
+// keychainError is an error type that is based on an OSStatus return code, and
+// obtains the error string with SecCopyErrorMessageString.
+type keychainError C.OSStatus
+
+func (e keychainError) Error() string {
+	s := C.SecCopyErrorMessageString(C.OSStatus(e), nil)
+	defer C.CFRelease(C.CFTypeRef(s))
+	return cfStringToString(s)
+}
+
+// cfDataToBytes turns a CFDataRef into a byte slice.
+func cfDataToBytes(cfData C.CFDataRef) []byte {
+	return C.GoBytes(unsafe.Pointer(C.CFDataGetBytePtr(cfData)), C.int(C.CFDataGetLength(cfData)))
+}
+
+// bytesToCFData turns a byte slice into a CFDataRef. Caller then "owns" the
+// CFDataRef and must CFRelease the CFDataRef when done.
+func bytesToCFData(buf []byte) C.CFDataRef {
+	return C.CFDataCreate(C.kCFAllocatorDefault, (*C.UInt8)(unsafe.Pointer(&buf[0])), C.CFIndex(len(buf)))
+}
+
+// int32ToCFNumber turns an int32 into a CFNumberRef. Caller then "owns"
+// the CFNumberRef and must CFRelease the CFNumberRef when done.
+func int32ToCFNumber(n int32) C.CFNumberRef {
+	return C.CFNumberCreate(C.kCFAllocatorDefault, C.kCFNumberSInt32Type, unsafe.Pointer(&n))
+}
+
+// Key is a wrapper around the Keychain reference that uses it to
+// implement signing-related methods with Keychain functionality.
+type Key struct {
+	privateKeyRef C.SecKeyRef
+	certs         []*x509.Certificate
+	once          sync.Once
+}
+
+// newKey makes a new Key wrapper around the key reference,
+// takes ownership of the reference, and sets up a finalizer to handle releasing
+// the reference.
+func newKey(privateKeyRef C.SecKeyRef, certs []*x509.Certificate) (*Key, error) {
+	k := &Key{
+		privateKeyRef: privateKeyRef,
+		certs:         certs,
+	}
+
+	// This struct now owns the key reference. Retain now and release on
+	// finalise in case the credential gets forgotten about.
+	C.CFRetain(C.CFTypeRef(privateKeyRef))
+	runtime.SetFinalizer(k, func(x interface{}) {
+		x.(*Key).Close()
+	})
+	return k, nil
+}
+
+// CertificateChain returns the credential as a raw X509 cert chain. This
+// contains the public key.
+func (k *Key) CertificateChain() [][]byte {
+	rv := make([][]byte, len(k.certs))
+	for i, c := range k.certs {
+		rv[i] = c.Raw
+	}
+	return rv
+}
+
+// Close releases resources held by the credential.
+func (k *Key) Close() error {
+	// Don't double-release references.
+	k.once.Do(func() {
+		C.CFRelease(C.CFTypeRef(k.privateKeyRef))
+	})
+	return nil
+}
+
+// Public returns the corresponding public key for this Key. Good
+// thing we extracted it when we created it.
+func (k *Key) Public() crypto.PublicKey {
+	return k.certs[0].PublicKey
+}
+
+// Sign signs a message digest. Here, we pass off the signing to Keychain library.
+func (k *Key) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	// Map the signing algorithm and hash function to a SecKeyAlgorithm constant.
+	var algorithms map[crypto.Hash]C.CFStringRef
+	switch pub := k.Public().(type) {
+	case *ecdsa.PublicKey:
+		algorithms = ecdsaAlgorithms
+	case *rsa.PublicKey:
+		if _, ok := opts.(*rsa.PSSOptions); ok {
+			algorithms = rsaPSSAlgorithms
+			break
+		}
+		algorithms = rsaPKCS1v15Algorithms
+	default:
+		return nil, fmt.Errorf("unsupported algorithm %T", pub)
+	}
+	algorithm, ok := algorithms[opts.HashFunc()]
+	if !ok {
+		return nil, fmt.Errorf("unsupported hash function %T", opts.HashFunc())
+	}
+
+	// Copy input over into CF-land.
+	cfDigest := bytesToCFData(digest)
+	defer C.CFRelease(C.CFTypeRef(cfDigest))
+
+	var cfErr C.CFErrorRef
+	sig := C.SecKeyCreateSignature(C.SecKeyRef(k.privateKeyRef), algorithm, C.CFDataRef(cfDigest), &cfErr)
+	if cfErr != 0 {
+		return nil, cfErrorFromRef(cfErr)
+	}
+	defer C.CFRelease(C.CFTypeRef(sig))
+
+	return cfDataToBytes(C.CFDataRef(sig)), nil
+}
+
+// Cred gets the first Credential (filtering on issuer) corresponding to
+// available certificate and private key pairs (i.e. identities) available in
+// the Keychain. This includes both the current login keychain for the user,
+// and the system keychain.
+func Cred(issuerCN string) (*Key, error) {
+	leafSearch := C.CFDictionaryCreateMutable(C.kCFAllocatorDefault, 5, &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
+	defer C.CFRelease(C.CFTypeRef(unsafe.Pointer(leafSearch)))
+	// Get identities (certificate + private key pairs).
+	C.CFDictionaryAddValue(leafSearch, unsafe.Pointer(C.kSecClass), unsafe.Pointer(C.kSecClassIdentity))
+	// Get identities that are signing capable.
+	C.CFDictionaryAddValue(leafSearch, unsafe.Pointer(C.kSecAttrCanSign), unsafe.Pointer(C.kCFBooleanTrue))
+	// For each identity, give us the reference to it.
+	C.CFDictionaryAddValue(leafSearch, unsafe.Pointer(C.kSecReturnRef), unsafe.Pointer(C.kCFBooleanTrue))
+	// Be sure to list out all the matches.
+	C.CFDictionaryAddValue(leafSearch, unsafe.Pointer(C.kSecMatchLimit), unsafe.Pointer(C.kSecMatchLimitAll))
+	// Do the matching-item copy.
+	var leafMatches C.CFTypeRef
+	if errno := C.SecItemCopyMatching((C.CFDictionaryRef)(leafSearch), &leafMatches); errno != C.errSecSuccess {
+		return nil, keychainError(errno)
+	}
+	defer C.CFRelease(leafMatches)
+	signingIdents := C.CFArrayRef(leafMatches)
+	// Dump the certs into golang x509 Certificates.
+	var (
+		leafIdent C.SecIdentityRef
+		leaf      *x509.Certificate
+	)
+	// Find the first valid leaf whose issuer (CA) matches the name in filter.
+	// Validation in identityToX509 covers Not Before, Not After and key alg.
+	for i := 0; i < int(C.CFArrayGetCount(signingIdents)) && leaf == nil; i++ {
+		identDict := C.CFArrayGetValueAtIndex(signingIdents, C.CFIndex(i))
+		xc, err := identityToX509(C.SecIdentityRef(identDict))
+		if err != nil {
+			continue
+		}
+		if xc.Issuer.CommonName == issuerCN {
+			leaf = xc
+			leafIdent = C.SecIdentityRef(identDict)
+		}
+	}
+
+	caSearch := C.CFDictionaryCreateMutable(C.kCFAllocatorDefault, 0, &C.kCFTypeDictionaryKeyCallBacks, &C.kCFTypeDictionaryValueCallBacks)
+	defer C.CFRelease(C.CFTypeRef(unsafe.Pointer(caSearch)))
+	// Get identities (certificates).
+	C.CFDictionaryAddValue(caSearch, unsafe.Pointer(C.kSecClass), unsafe.Pointer(C.kSecClassCertificate))
+	// For each identity, give us the reference to it.
+	C.CFDictionaryAddValue(caSearch, unsafe.Pointer(C.kSecReturnRef), unsafe.Pointer(C.kCFBooleanTrue))
+	// Be sure to list out all the matches.
+	C.CFDictionaryAddValue(caSearch, unsafe.Pointer(C.kSecMatchLimit), unsafe.Pointer(C.kSecMatchLimitAll))
+	// Do the matching-item copy.
+	var caMatches C.CFTypeRef
+	if errno := C.SecItemCopyMatching((C.CFDictionaryRef)(caSearch), &caMatches); errno != C.errSecSuccess {
+		return nil, keychainError(errno)
+	}
+	defer C.CFRelease(caMatches)
+	certRefs := C.CFArrayRef(caMatches)
+	// Validate and dump the certs into golang x509 Certificates.
+	var allCerts []*x509.Certificate
+	for i := 0; i < int(C.CFArrayGetCount(certRefs)); i++ {
+		refDict := C.CFArrayGetValueAtIndex(certRefs, C.CFIndex(i))
+		if xc, err := certRefToX509(C.SecCertificateRef(refDict)); err == nil {
+			allCerts = append(allCerts, xc)
+		}
+	}
+
+	// Build a certificate chain from leaf by matching prev.RawIssuer to
+	// next.RawSubject across all valid certificates in the keychain.
+	var (
+		certs      []*x509.Certificate
+		prev, next *x509.Certificate
+	)
+	for prev = leaf; prev != nil; prev, next = next, nil {
+		certs = append(certs, prev)
+		for _, xc := range allCerts {
+			if certIn(xc, certs) {
+				continue // finite chains only, mmmmkay.
+			}
+			if bytes.Equal(prev.RawIssuer, xc.RawSubject) && prev.CheckSignatureFrom(xc) == nil {
+				// Prefer certificates with later expirations.
+				if next == nil || xc.NotAfter.After(next.NotAfter) {
+					next = xc
+				}
+			}
+		}
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no key found with issuer common name %q", issuerCN)
+	}
+
+	skr, err := identityToSecKeyRef(leafIdent)
+	if err != nil {
+		return nil, err
+	}
+	defer C.CFRelease(C.CFTypeRef(skr))
+	return newKey(skr, certs)
+}
+
+// identityToX509 converts a single CFDictionary that contains the item ref and
+// attribute dictionary into an x509.Certificate.
+func identityToX509(ident C.SecIdentityRef) (*x509.Certificate, error) {
+	var certRef C.SecCertificateRef
+	if errno := C.SecIdentityCopyCertificate(ident, &certRef); errno != 0 {
+		return nil, keychainError(errno)
+	}
+	defer C.CFRelease(C.CFTypeRef(certRef))
+
+	return certRefToX509(certRef)
+}
+
+// certRefToX509 converts a single C.SecCertificateRef into an *x509.Certificate.
+func certRefToX509(certRef C.SecCertificateRef) (*x509.Certificate, error) {
+	// Export the PEM-encoded certificate to a CFDataRef.
+	var certPEMData C.CFDataRef
+	if errno := C.SecItemExport(C.CFTypeRef(certRef), C.kSecFormatUnknown, C.kSecItemPemArmour, nil, &certPEMData); errno != 0 {
+		return nil, keychainError(errno)
+	}
+	defer C.CFRelease(C.CFTypeRef(certPEMData))
+	certPEM := cfDataToBytes(certPEMData)
+
+	// This part based on crypto/tls.
+	var certDERBlock *pem.Block
+	for {
+		certDERBlock, certPEM = pem.Decode(certPEM)
+		if certDERBlock == nil {
+			return nil, fmt.Errorf("failed to parse certificate PEM data")
+		}
+		if certDERBlock.Type == "CERTIFICATE" {
+			// found it
+			break
+		}
+	}
+
+	// Check the certificate is OK by the x509 library, and obtain the
+	// public key algorithm (which I assume is the same as the private key
+	// algorithm). This also filters out certs missing critical extensions.
+	xc, err := x509.ParseCertificate(certDERBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	switch xc.PublicKey.(type) {
+	case *rsa.PublicKey, *ecdsa.PublicKey:
+	default:
+		return nil, fmt.Errorf("unsupported key type %T", xc.PublicKey)
+	}
+
+	// Check the certificate is valid
+	if n := time.Now(); n.Before(xc.NotBefore) || n.After(xc.NotAfter) {
+		return nil, fmt.Errorf("certificate not valid")
+	}
+
+	return xc, nil
+}
+
+// identityToSecKeyRef converts a single CFDictionary that contains the item ref and
+// attribute dictionary into a SecKeyRef for its private key.
+func identityToSecKeyRef(ident C.SecIdentityRef) (C.SecKeyRef, error) {
+	// Get the private key (ref). Note that "Copy" in "CopyPrivateKey"
+	// refers to "the create rule" of CoreFoundation memory management, and
+	// does not actually copy the private key---it gives us a copy of the
+	// reference that we now own.
+	var ref C.SecKeyRef
+	if errno := C.SecIdentityCopyPrivateKey(C.SecIdentityRef(ident), &ref); errno != 0 {
+		return 0, keychainError(errno)
+	}
+	return ref, nil
+}
+
+func stringIn(s string, ss []string) bool {
+	for _, s2 := range ss {
+		if s == s2 {
+			return true
+		}
+	}
+	return false
+}
+
+func certIn(xc *x509.Certificate, xcs []*x509.Certificate) bool {
+	for _, xc2 := range xcs {
+		if xc.Equal(xc2) {
+			return true
+		}
+	}
+	return false
+}

--- a/third_party/ecpsigner/darwin/keychain/keychain_test.go
+++ b/third_party/ecpsigner/darwin/keychain/keychain_test.go
@@ -1,0 +1,48 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin && cgo
+// +build darwin,cgo
+
+package keychain
+
+import (
+	"bytes"
+	"testing"
+	"unsafe"
+)
+
+func TestKeychainError(t *testing.T) {
+	tests := []struct {
+		e    keychainError
+		want string
+	}{
+		{e: keychainError(0), want: "No error."},
+		{e: keychainError(-4), want: "Function or operation not implemented."},
+	}
+
+	for i, test := range tests {
+		if got := test.e.Error(); got != test.want {
+			t.Errorf("test %d: %#v.Error() = %q, want %q", i, test.e, got, test.want)
+		}
+	}
+}
+
+func TestBytesToCFDataRoundTrip(t *testing.T) {
+	want := []byte("an arbitrary and yet coherent byte slice!")
+	d := bytesToCFData(want)
+	defer cfRelease(unsafe.Pointer(d))
+	if got := cfDataToBytes(d); !bytes.Equal(got, want) {
+		t.Errorf("bytesToCFData -> cfDataToBytes\ngot  %x\nwant %x", got, want)
+	}
+}

--- a/third_party/ecpsigner/windows/ncrypt/cert_util.go
+++ b/third_party/ecpsigner/windows/ncrypt/cert_util.go
@@ -1,0 +1,300 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+// Cert_util provides helpers for working with Windows certificates via crypt32.dll
+
+package ncrypt
+
+import (
+	"crypto"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// wincrypt.h constants
+	encodingX509ASN                   = 1                                              // X509_ASN_ENCODING
+	certStoreCurrentUserID            = 1                                              // CERT_SYSTEM_STORE_CURRENT_USER_ID
+	certStoreLocalMachineID           = 2                                              // CERT_SYSTEM_STORE_LOCAL_MACHINE_ID
+	infoIssuerFlag                    = 4                                              // CERT_INFO_ISSUER_FLAG
+	compareNameStrW                   = 8                                              // CERT_COMPARE_NAME_STR_A
+	certStoreProvSystem               = 10                                             // CERT_STORE_PROV_SYSTEM
+	compareShift                      = 16                                             // CERT_COMPARE_SHIFT
+	locationShift                     = 16                                             // CERT_SYSTEM_STORE_LOCATION_SHIFT
+	findIssuerStr                     = compareNameStrW<<compareShift | infoIssuerFlag // CERT_FIND_ISSUER_STR_W
+	certStoreLocalMachine             = certStoreLocalMachineID << locationShift       // CERT_SYSTEM_STORE_LOCAL_MACHINE
+	certStoreCurrentUser              = certStoreCurrentUserID << locationShift        // CERT_SYSTEM_STORE_CURRENT_USER
+	signatureKeyUsage                 = 0x80                                           // CERT_DIGITAL_SIGNATURE_KEY_USAGE
+	acquireCached                     = 0x1                                            // CRYPT_ACQUIRE_CACHE_FLAG
+	acquireSilent                     = 0x40                                           // CRYPT_ACQUIRE_SILENT_FLAG
+	acquireOnlyNCryptKey              = 0x40000                                        // CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG
+	ncryptKeySpec                     = 0xFFFFFFFF                                     // CERT_NCRYPT_KEY_SPEC
+	certChainCacheOnlyURLRetrieval    = 0x00000004                                     // CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL
+	certChainDisableAIA               = 0x00002000                                     // CERT_CHAIN_DISABLE_AIA
+	certChainRevocationCheckCacheOnly = 0x80000000                                     // CERT_CHAIN_REVOCATION_CHECK_CACHE_ONLY
+
+	hcceLocalMachine = windows.Handle(0x01) // HCCE_LOCAL_MACHINE
+
+	// winerror.h constants
+	cryptENotFound = 0x80092004 // CRYPT_E_NOT_FOUND
+)
+
+var (
+	null = uintptr(unsafe.Pointer(nil))
+
+	crypt32 = windows.MustLoadDLL("crypt32.dll")
+
+	certFindCertificateInStore        = crypt32.MustFindProc("CertFindCertificateInStore")
+	certGetIntendedKeyUsage           = crypt32.MustFindProc("CertGetIntendedKeyUsage")
+	cryptAcquireCertificatePrivateKey = crypt32.MustFindProc("CryptAcquireCertificatePrivateKey")
+)
+
+// findCert wraps the CertFindCertificateInStore call. Note that any cert context passed
+// into prev will be freed. If no certificate was found, nil will be returned.
+func findCert(store windows.Handle, enc uint32, findFlags uint32, findType uint32, para *uint16, prev *windows.CertContext) (*windows.CertContext, error) {
+	h, _, err := certFindCertificateInStore.Call(
+		uintptr(store),
+		uintptr(enc),
+		uintptr(findFlags),
+		uintptr(findType),
+		uintptr(unsafe.Pointer(para)),
+		uintptr(unsafe.Pointer(prev)),
+	)
+	if h == 0 {
+		// Actual error, or simply not found?
+		errno, ok := err.(syscall.Errno)
+		if !ok {
+			return nil, err
+		}
+		if errno == cryptENotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return (*windows.CertContext)(unsafe.Pointer(h)), nil
+}
+
+// extractSimpleChain extracts the final certificate chain from a CertSimpleChain.
+// Adapted from crypto.x509.root_windows
+func extractSimpleChain(simpleChain **windows.CertSimpleChain, chainCount int) ([]*x509.Certificate, error) {
+	if simpleChain == nil || chainCount == 0 {
+		return nil, errors.New("invalid simple chain")
+	}
+	// Convert the simpleChain array to a huge slice and slice it to the length we want.
+	// https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices
+	simpleChains := (*[1 << 20]*windows.CertSimpleChain)(unsafe.Pointer(simpleChain))[:chainCount:chainCount]
+	// Each simple chain contains the chain of certificates, summary trust information
+	// about the chain, and trust information about each certificate element in the chain.
+	// Select the last chain since only expect to encounter one chain.
+	lastChain := simpleChains[chainCount-1]
+	chainLen := int(lastChain.NumElements)
+	elements := (*[1 << 20]*windows.CertChainElement)(unsafe.Pointer(lastChain.Elements))[:chainLen:chainLen]
+	chain := make([]*x509.Certificate, 0, chainLen)
+	for _, element := range elements {
+		xc, err := certContextToX509(element.CertContext)
+		if err != nil {
+			return nil, err
+		}
+		chain = append(chain, xc)
+	}
+	return chain, nil
+}
+
+// findCertChain builds a chain from a given certificate using the local machine store.
+func findCertChain(cert *windows.CertContext) ([]*x509.Certificate, error) {
+	var (
+		chainPara windows.CertChainPara
+		chainCtx  *windows.CertChainContext
+	)
+
+	// Search the system for candidate certificate chains.
+	// Because we are using unsafe pointers here, we CANNOT directly call
+	// CertGetCertificateChain and MUST either use the windows or syscall library
+	// to validly use unsafe pointers.
+	// See https://golang.org/pkg/unsafe/#Pointer for valid unsafe package patterns.
+	chainPara.Size = uint32(unsafe.Sizeof(chainPara))
+	err := windows.CertGetCertificateChain(
+		hcceLocalMachine,
+		cert,
+		nil,
+		cert.Store,
+		&chainPara,
+		certChainRevocationCheckCacheOnly|certChainCacheOnlyURLRetrieval|certChainDisableAIA,
+		0,
+		&chainCtx)
+
+	if err != nil {
+		return nil, fmt.Errorf("getCertificateChain: %w", err)
+	}
+	defer windows.CertFreeCertificateChain(chainCtx)
+
+	x509Certs, err := extractSimpleChain(chainCtx.Chains, int(chainCtx.ChainCount))
+	if err != nil {
+		return nil, fmt.Errorf("getCertificateChain extractSimpleChain: %w", err)
+	}
+	return x509Certs, nil
+}
+
+// intendedKeyUsage wraps CertGetIntendedKeyUsage. If there are key usage bytes they will be returned,
+// otherwise 0 will be returned.
+func intendedKeyUsage(enc uint32, cert *windows.CertContext) (usage uint16) {
+	_, _, _ = certGetIntendedKeyUsage.Call(uintptr(enc), uintptr(unsafe.Pointer(cert.CertInfo)), uintptr(unsafe.Pointer(&usage)), 2)
+	return
+}
+
+// acquirePrivateKey wraps CryptAcquireCertificatePrivateKey.
+func acquirePrivateKey(cert *windows.CertContext) (windows.Handle, error) {
+	var (
+		key      windows.Handle
+		keySpec  uint32
+		mustFree int
+	)
+	r, _, err := cryptAcquireCertificatePrivateKey.Call(
+		uintptr(unsafe.Pointer(cert)),
+		acquireCached|acquireSilent|acquireOnlyNCryptKey,
+		null,
+		uintptr(unsafe.Pointer(&key)),
+		uintptr(unsafe.Pointer(&keySpec)),
+		uintptr(unsafe.Pointer(&mustFree)),
+	)
+	if r == 0 {
+		return 0, fmt.Errorf("acquiring private key: %x %w", r, err)
+	}
+	if mustFree != 0 {
+		return 0, fmt.Errorf("wrong mustFree [%d != 0]", mustFree)
+	}
+	if keySpec != ncryptKeySpec {
+		return 0, fmt.Errorf("wrong keySpec [%d != %d]", keySpec, ncryptKeySpec)
+	}
+	return key, nil
+}
+
+// certContextToX509 extracts the x509 certificate from the cert context.
+func certContextToX509(ctx *windows.CertContext) (*x509.Certificate, error) {
+	// To ensure we don't mess with the cert context's memory, use a copy of it.
+	src := (*[1 << 20]byte)(unsafe.Pointer(ctx.EncodedCert))[:ctx.Length:ctx.Length]
+	der := make([]byte, int(ctx.Length))
+	copy(der, src)
+
+	xc, err := x509.ParseCertificate(der)
+	if err != nil {
+		return xc, err
+	}
+	return xc, nil
+}
+
+// Cred returns a Key wrapping the first valid certificate in the system store
+// matching a given issuer string.
+func Cred(issuer string, storeName string, provider string) (*Key, error) {
+	var certStore uint32
+	if provider == "local_machine" {
+		certStore = uint32(certStoreLocalMachine)
+	} else if provider == "current_user" {
+		certStore = uint32(certStoreCurrentUser)
+	} else {
+		return nil, errors.New("provider must be local_machine or current_user")
+	}
+	storeNamePtr, err := windows.UTF16PtrFromString(storeName)
+	if err != nil {
+		return nil, err
+	}
+	store, err := windows.CertOpenStore(certStoreProvSystem, 0, null, certStore, uintptr(unsafe.Pointer(storeNamePtr)))
+	if err != nil {
+		return nil, fmt.Errorf("opening certificate store: %w", err)
+	}
+	i, err := windows.UTF16PtrFromString(issuer)
+	if err != nil {
+		return nil, err
+	}
+	var prev *windows.CertContext
+	for {
+		nc, err := findCert(store, encodingX509ASN, 0, findIssuerStr, i, prev)
+		if err != nil {
+			return nil, fmt.Errorf("finding certificates: %w", err)
+		}
+		if nc == nil {
+			return nil, errors.New("no certificate found")
+		}
+		prev = nc
+		if (intendedKeyUsage(encodingX509ASN, nc) & signatureKeyUsage) == 0 {
+			continue
+		}
+
+		xc, err := certContextToX509(nc)
+		if err != nil {
+			continue
+		}
+
+		machineChain, err := findCertChain(nc)
+		if err != nil {
+			continue
+		}
+		return &Key{
+			cert:  xc,
+			ctx:   nc,
+			store: store,
+			chain: machineChain,
+		}, nil
+	}
+}
+
+// Key is a wrapper around the certificate store and context that uses it to
+// implement signing-related methods with CryptoNG functionality.
+type Key struct {
+	cert  *x509.Certificate
+	ctx   *windows.CertContext
+	store windows.Handle
+	chain []*x509.Certificate
+}
+
+// CertificateChain returns the credential as a raw X509 cert chain. This
+// contains the public key.
+func (k *Key) CertificateChain() [][]byte {
+	// Convert the certificates to a list of encoded certificate bytes.
+	chain := make([][]byte, len(k.chain))
+	for i, xc := range k.chain {
+		chain[i] = xc.Raw
+	}
+	return chain
+}
+
+// Close releases resources held by the credential.
+func (k *Key) Close() error {
+	if err := windows.CertFreeCertificateContext(k.ctx); err != nil {
+		return err
+	}
+	return windows.CertCloseStore(k.store, 0)
+}
+
+// Public returns the corresponding public key for this Key.
+func (k *Key) Public() crypto.PublicKey {
+	return k.cert.PublicKey
+}
+
+// Sign signs a message digest. Here, we pass off the signing to the Windows CryptoNG library.
+func (k *Key) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	key, err := acquirePrivateKey(k.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cannot acquire private key handle: %w", err)
+	}
+	return SignHash(key, k.Public(), digest, opts)
+}

--- a/third_party/ecpsigner/windows/ncrypt/cert_util_test.go
+++ b/third_party/ecpsigner/windows/ncrypt/cert_util_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+package ncrypt
+
+import (
+	"testing"
+)
+
+func TestCredProviderNotSupported(t *testing.T) {
+	_, err := Cred("issuer", "store", "unsupported_provider")
+	if err == nil {
+		t.Errorf("Expected error, but got nil.")
+	}
+	want := "provider must be local_machine or current_user"
+	if err.Error() != want {
+		t.Errorf("Expected error is %q, got: %q", want, err.Error())
+	}
+}

--- a/third_party/ecpsigner/windows/ncrypt/ncrypt.go
+++ b/third_party/ecpsigner/windows/ncrypt/ncrypt.go
@@ -1,0 +1,170 @@
+// Copyright 2022 Google LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+// +build windows
+
+// Package ncrypt provides wrappers around ncrypt.h functions.
+// https://docs.microsoft.com/en-us/windows/win32/api/ncrypt/
+package ncrypt
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"fmt"
+	"math/big"
+	"unsafe"
+
+	"golang.org/x/crypto/cryptobyte"
+	"golang.org/x/crypto/cryptobyte/asn1"
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// bcrypt.h constants
+	bcryptPadPKCS1 = 0x00000002 // BCRYPT_PAD_PKCS1
+	bcryptPadPSS   = 0x00000008 // BCRYPT_PAD_PSS
+
+	// ncrypt.h constants
+	nCryptSilentFlag = 0x00000040 // NCRYPT_SILENT_FLAG
+)
+
+var (
+	nCrypt         = windows.MustLoadDLL("ncrypt.dll")
+	nCryptSignHash = nCrypt.MustFindProc("NCryptSignHash")
+)
+
+// bcypt.h structs.
+type pkcs1PaddingInfo struct {
+	algID *uint16
+}
+type pssPaddingInfo struct {
+	algID      *uint16
+	saltLength uint32
+}
+
+func algID(hashFunc crypto.Hash) (*uint16, bool) {
+	algID, ok := map[crypto.Hash][]uint16{
+		crypto.SHA256: {'S', 'H', 'A', '2', '5', '6', 0}, // BCRYPT_SHA256_ALGORITHM
+	}[hashFunc]
+	return &algID[0], ok
+}
+
+func rsaPadding(opts crypto.SignerOpts, flags *int) (paddingInfo unsafe.Pointer, err error) {
+	if o, ok := opts.(*rsa.PSSOptions); ok {
+		algID, ok := algID(o.HashFunc())
+		if !ok {
+			err = fmt.Errorf("unsupported hash function %T", o.HashFunc())
+			return
+		}
+		saltLength := o.SaltLength
+		switch saltLength {
+		case rsa.PSSSaltLengthAuto:
+			err = fmt.Errorf("rsa.PSSSaltLengthAuto is not supported")
+			return
+		case rsa.PSSSaltLengthEqualsHash:
+			saltLength = o.HashFunc().Size()
+		}
+		paddingInfo = unsafe.Pointer(&pssPaddingInfo{
+			algID:      algID,
+			saltLength: uint32(saltLength),
+		})
+		*flags |= bcryptPadPSS
+		return
+	}
+
+	algID, ok := algID(opts.HashFunc())
+	if !ok {
+		err = fmt.Errorf("unsupported hash function %T", opts.HashFunc())
+		return
+	}
+	paddingInfo = unsafe.Pointer(&pkcs1PaddingInfo{
+		algID: algID,
+	})
+	*flags |= bcryptPadPKCS1
+	return
+}
+
+func signHashInternal(priv windows.Handle, pub crypto.PublicKey, digest []byte, flags int, paddingInfo unsafe.Pointer) ([]byte, error) {
+	var size uint32
+	r, _, _ := nCryptSignHash.Call(
+		/* hKey */ uintptr(priv),
+		/* *pPaddingInfo */ uintptr(paddingInfo),
+		/* pbHashValue */ uintptr(unsafe.Pointer(&digest[0])),
+		/* cbHashValue */ uintptr(len(digest)),
+		/* pbSignature */ 0,
+		/* cbSignature */ 0,
+		/* *pcbResult */ uintptr(unsafe.Pointer(&size)),
+		/* dwFlagss */ uintptr(flags))
+	if r != 0 {
+		return nil, fmt.Errorf("NCryptSignHash: failed to get signature length: %#x", r)
+	}
+
+	sig := make([]byte, size)
+	r, _, _ = nCryptSignHash.Call(
+		/* hKey */ uintptr(priv),
+		/* *pPaddingInfo */ uintptr(paddingInfo),
+		/* pbHashValue */ uintptr(unsafe.Pointer(&digest[0])),
+		/* cbHashValue */ uintptr(len(digest)),
+		/* pbSignature */ uintptr(unsafe.Pointer(&sig[0])),
+		/* cbSignature */ uintptr(size),
+		/* *pcbResult */ uintptr(unsafe.Pointer(&size)),
+		/* dwFlagss */ uintptr(flags))
+	if r != 0 {
+		return nil, fmt.Errorf("NCryptSignHash: failed to get signature: %#x", r)
+	}
+	if len(sig) != int(size) {
+		return nil, fmt.Errorf("invalid length sig = %d, size = %d", sig, size)
+	}
+
+	switch pub := pub.(type) {
+	case *ecdsa.PublicKey:
+		var b cryptobyte.Builder
+		b.AddASN1(asn1.SEQUENCE, func(b *cryptobyte.Builder) {
+			b.AddASN1BigInt(new(big.Int).SetBytes(sig[:len(sig)/2]))
+			b.AddASN1BigInt(new(big.Int).SetBytes(sig[len(sig)/2:]))
+		})
+		return b.Bytes()
+	case *rsa.PublicKey:
+		return sig, nil
+	default:
+		return nil, fmt.Errorf("unsupported public key type %T", pub)
+	}
+}
+
+// SignHash is a wrapper for the NCryptSignHash function that supports only a
+// subset of well-supported cryptographic primitives.
+//
+// Signature algorithms: ECDSA, RSA.
+// Hash functions: SHA-256.
+// RSA schemes: RSASSA-PKCS1 and RSASSA-PSS.
+//
+// https://docs.microsoft.com/en-us/windows/win32/api/ncrypt/nf-ncrypt-ncryptsignhash
+func SignHash(priv windows.Handle, pub crypto.PublicKey, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	var paddingInfo unsafe.Pointer
+	flags := nCryptSilentFlag
+	switch pub := pub.(type) {
+	case *ecdsa.PublicKey:
+	case *rsa.PublicKey:
+		var err error
+		paddingInfo, err = rsaPadding(opts, &flags)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported public key type %T", pub)
+	}
+
+	return signHashInternal(priv, pub, digest, flags, paddingInfo)
+}


### PR DESCRIPTION
## Summary

Vendor some files from the internal/signer directory in https://github.com/googleapis/enterprise-certificate-proxy/ into a new package 'third_party/ecpsigner'.

The enterprise-certificate-proxy code is licensed under the Apache License 2.0. These files were copied as of the v0.2.5 tag in that repository. No modifications were made to these files.

## Related issues

In preparation for https://github.com/pomerium/cli/issues/308.


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
