### PR TITLE
update version command

### DIFF
--- a/cmd/pomerium-cli/version.go
+++ b/cmd/pomerium-cli/version.go
@@ -14,6 +14,6 @@ var versionCmd = &cobra.Command{
 	Long:  `Print the cli version.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		rootCmd.SetArgs([]string{"--version"})
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 	},
 }

--- a/cmd/pomerium-cli/version.go
+++ b/cmd/pomerium-cli/version.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-
-	"github.com/pomerium/cli/version"
 )
 
 func init() {
@@ -17,6 +13,7 @@ var versionCmd = &cobra.Command{
 	Short: "version",
 	Long:  `Print the cli version.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("pomerium:", version.FullVersion())
+		rootCmd.SetArgs([]string{"--version"})
+		rootCmd.Execute()
 	},
 }


### PR DESCRIPTION
## Summary

Currently pomerium-cli has both a `version` command and a `--version` flag, and the output differs slightly between these two. To ensure that these two stay in sync, change the `version` command so that it delegates to the root command with the args overwritten to contain just `--version`.

## Related issues

Fixes #336.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
