### PR TITLE
ncrypt: open cert store in readonly mode

### DIFF
--- a/third_party/ecpsigner/windows/ncrypt/cert_util.go
+++ b/third_party/ecpsigner/windows/ncrypt/cert_util.go
@@ -45,6 +45,7 @@ const (
 	findIssuerStr                     = compareNameStrW<<compareShift | infoIssuerFlag // CERT_FIND_ISSUER_STR_W
 	certStoreLocalMachine             = certStoreLocalMachineID << locationShift       // CERT_SYSTEM_STORE_LOCAL_MACHINE
 	certStoreCurrentUser              = certStoreCurrentUserID << locationShift        // CERT_SYSTEM_STORE_CURRENT_USER
+	certStoreReadonlyFlag             = 0x00008000                                     // CERT_STORE_READONLY_FLAG
 	signatureKeyUsage                 = 0x80                                           // CERT_DIGITAL_SIGNATURE_KEY_USAGE
 	acquireCached                     = 0x1                                            // CRYPT_ACQUIRE_CACHE_FLAG
 	acquireSilent                     = 0x40                                           // CRYPT_ACQUIRE_SILENT_FLAG
@@ -52,7 +53,6 @@ const (
 	ncryptKeySpec                     = 0xFFFFFFFF                                     // CERT_NCRYPT_KEY_SPEC
 	certChainCacheOnlyURLRetrieval    = 0x00000004                                     // CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL
 	certChainDisableAIA               = 0x00002000                                     // CERT_CHAIN_DISABLE_AIA
-	certStoreReadonlyFlag             = 0x00008000                                     // CERT_STORE_READONLY_FLAG
 	certChainRevocationCheckCacheOnly = 0x80000000                                     // CERT_CHAIN_REVOCATION_CHECK_CACHE_ONLY
 
 	hcceLocalMachine = windows.Handle(0x01) // HCCE_LOCAL_MACHINE

--- a/third_party/ecpsigner/windows/ncrypt/cert_util.go
+++ b/third_party/ecpsigner/windows/ncrypt/cert_util.go
@@ -1,4 +1,6 @@
 // Copyright 2022 Google LLC.
+// Copyright 2023 Pomerium Inc.
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -50,6 +52,7 @@ const (
 	ncryptKeySpec                     = 0xFFFFFFFF                                     // CERT_NCRYPT_KEY_SPEC
 	certChainCacheOnlyURLRetrieval    = 0x00000004                                     // CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL
 	certChainDisableAIA               = 0x00002000                                     // CERT_CHAIN_DISABLE_AIA
+	certStoreReadonlyFlag             = 0x00008000                                     // CERT_STORE_READONLY_FLAG
 	certChainRevocationCheckCacheOnly = 0x80000000                                     // CERT_CHAIN_REVOCATION_CHECK_CACHE_ONLY
 
 	hcceLocalMachine = windows.Handle(0x01) // HCCE_LOCAL_MACHINE
@@ -213,6 +216,7 @@ func Cred(issuer string, storeName string, provider string) (*Key, error) {
 	} else {
 		return nil, errors.New("provider must be local_machine or current_user")
 	}
+	certStore |= certStoreReadonlyFlag
 	storeNamePtr, err := windows.UTF16PtrFromString(storeName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

On Windows, trying to open the LocalMachine cert store may require administrator permissions for the default mode (read/write). However, if we include the `CERT_STORE_READONLY_FLAG` option this appears to allow opening the cert store without running as admin.

Add a Pomerium copyright line to the modified file, to serve as "prominent notice" that this file has been modified, per clause 4(b) of the Apache License 2.0 (on the recommendation of https://opensource.stackexchange.com/a/13150).

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
