### PR TITLE
api: discard unknown config proto fields

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -46,7 +46,8 @@ func loadConfig(ls ConfigProvider) (*config, error) {
 	}
 
 	any := new(anypb.Any)
-	if err = protojson.Unmarshal(data, any); err != nil {
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err = opts.Unmarshal(data, any); err != nil {
 		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

The `pomerium-cli api` command will persist its state as a protobuf serialized to JSON. If a newer version of pomerium-cli introduces new fields in this protobuf message, an older version of pomerium-cli may not be able to start — currently it will exit if there is any error when unmarshaling this state.

(Ordinarily, adding a field to a proto message is a backwards-compatible change: any software built with the older definition of the proto will generally not notice the new field. However, it looks like the protojson library `Unmarshal()` method will return an error for any unknown fields present in the JSON data.)

Let's change this behavior, by setting the `DiscardUnknown` option. This way, an older pomerium-cli binary won't quit on startup if it encounters an unknown option. Instead it will accept all the configuration options it knows about, and ignore the rest. This seems preferably to resetting the configuration entirely.

## Related issues

https://github.com/pomerium/desktop-client/issues/319

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
