### PR TITLE
update Go base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-bookworm@sha256:d0214956a9c50c300e430c1f6c0a820007ace238e5242c53762e61b344659e05 as build
+FROM golang:1.21.3-bookworm@sha256:5bafbbb109f02aaf6b41ddc19f54919773c3006f1cbda1599112603367642f0e as build
 WORKDIR /go/src/github.com/pomerium/cli
 
 # cache depedency downloads


### PR DESCRIPTION
## Summary

Update the `golang:1.21.3-bookworm` base image to the current multi-platform manifest digest for this tag.

## Related issues

- https://github.com/pomerium/internal/issues/1519#issuecomment-1828428428


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
