### PR TITLE
cli/cmd: add commands for viewing the cache location and clearing it

### DIFF
--- a/cmd/pomerium-cli/cache.go
+++ b/cmd/pomerium-cli/cache.go
@@ -10,7 +10,45 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/spf13/cobra"
 )
+
+var cacheCmd = &cobra.Command{
+	Use:   "cache",
+	Short: "commands for working with the cache",
+}
+
+var cacheClearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "clear the cache",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		root, err := os.UserCacheDir()
+		if err != nil {
+			return err
+		}
+		return os.RemoveAll(filepath.Join(root, "pomerium-cli"))
+	},
+}
+
+var cacheLocationCmd = &cobra.Command{
+	Use:   "location",
+	Short: "print the cache location",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		root, err := os.UserCacheDir()
+		if err != nil {
+			return err
+		}
+		fmt.Println(filepath.Join(root, "pomerium-cli"))
+		return nil
+	},
+}
+
+func init() {
+	cacheCmd.AddCommand(cacheClearCmd)
+	cacheCmd.AddCommand(cacheLocationCmd)
+	rootCmd.AddCommand(cacheCmd)
+}
 
 func cachePath() (string, error) {
 	root, err := os.UserCacheDir()

--- a/cmd/pomerium-cli/cache.go
+++ b/cmd/pomerium-cli/cache.go
@@ -23,11 +23,11 @@ var cacheClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "clear the cache",
 	RunE: func(_ *cobra.Command, _ []string) error {
-		root, err := os.UserCacheDir()
+		root, err := cachePath()
 		if err != nil {
 			return err
 		}
-		return os.RemoveAll(filepath.Join(root, "pomerium-cli"))
+		return os.RemoveAll(root)
 	},
 }
 
@@ -35,11 +35,11 @@ var cacheLocationCmd = &cobra.Command{
 	Use:   "location",
 	Short: "print the cache location",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root, err := os.UserCacheDir()
+		root, err := cachePath()
 		if err != nil {
 			return err
 		}
-		fmt.Println(filepath.Join(root, "pomerium-cli"))
+		fmt.Println(root)
 		return nil
 	},
 }
@@ -55,14 +55,22 @@ func cachePath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(root, "pomerium-cli", "exec-credential"), nil
+	return filepath.Join(root, "pomerium-cli"), nil
+}
+
+func cachedCredentialsPath() (string, error) {
+	root, err := cachePath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "exec-credential"), nil
 }
 
 func cachedCredentialPath(serverURL string) (string, error) {
 	h := sha256.New()
 	_, _ = h.Write([]byte(serverURL))
 	id := hex.EncodeToString(h.Sum(nil))
-	p, err := cachePath()
+	p, err := cachedCredentialsPath()
 	if err != nil {
 		return "", err
 	}
@@ -70,7 +78,7 @@ func cachedCredentialPath(serverURL string) (string, error) {
 }
 
 func clearAllCachedCredentials() error {
-	cache, err := cachePath()
+	cache, err := cachedCredentialsPath()
 	if err != nil {
 		return err
 	}

--- a/cmd/pomerium-cli/cache.go
+++ b/cmd/pomerium-cli/cache.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/pomerium/cli/internal/cache"
 )
 
 var cacheCmd = &cobra.Command{
@@ -23,11 +25,7 @@ var cacheClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "clear the cache",
 	RunE: func(_ *cobra.Command, _ []string) error {
-		root, err := cachePath()
-		if err != nil {
-			return err
-		}
-		return os.RemoveAll(root)
+		return cache.Clear()
 	},
 }
 
@@ -35,7 +33,7 @@ var cacheLocationCmd = &cobra.Command{
 	Use:   "location",
 	Short: "print the cache location",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		root, err := cachePath()
+		root, err := cache.RootPath()
 		if err != nil {
 			return err
 		}
@@ -50,27 +48,11 @@ func init() {
 	rootCmd.AddCommand(cacheCmd)
 }
 
-func cachePath() (string, error) {
-	root, err := os.UserCacheDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(root, "pomerium-cli"), nil
-}
-
-func cachedCredentialsPath() (string, error) {
-	root, err := cachePath()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(root, "exec-credential"), nil
-}
-
 func cachedCredentialPath(serverURL string) (string, error) {
 	h := sha256.New()
 	_, _ = h.Write([]byte(serverURL))
 	id := hex.EncodeToString(h.Sum(nil))
-	p, err := cachedCredentialsPath()
+	p, err := cache.ExecCredentialsPath()
 	if err != nil {
 		return "", err
 	}
@@ -78,7 +60,7 @@ func cachedCredentialPath(serverURL string) (string, error) {
 }
 
 func clearAllCachedCredentials() error {
-	cache, err := cachedCredentialsPath()
+	cache, err := cache.ExecCredentialsPath()
 	if err != nil {
 		return err
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,43 @@
+// Package cache contains functions for working with caches.
+package cache
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Clear clears the cache.
+func Clear() error {
+	root, err := RootPath()
+	if err != nil {
+		return err
+	}
+	return os.RemoveAll(root)
+}
+
+// RootPath returns the root cache path.
+func RootPath() (string, error) {
+	root, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "pomerium-cli"), nil
+}
+
+// ExecCredentialsPath returns the path to the exec credentials.
+func ExecCredentialsPath() (string, error) {
+	root, err := RootPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "exec-credential"), nil
+}
+
+// JWTsPath returns the path to the jwts.
+func JWTsPath() (string, error) {
+	root, err := RootPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "jwts"), nil
+}

--- a/jwt/jwtcache.go
+++ b/jwt/jwtcache.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-jose/go-jose/v3"
 	"github.com/martinlindhe/base36"
 
+	"github.com/pomerium/cli/internal/cache"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
@@ -36,12 +37,10 @@ type LocalJWTCache struct {
 
 // NewLocalJWTCache creates a new LocalJWTCache.
 func NewLocalJWTCache() (*LocalJWTCache, error) {
-	root, err := os.UserCacheDir()
+	dir, err := cache.JWTsPath()
 	if err != nil {
 		return nil, err
 	}
-
-	dir := filepath.Join(root, "pomerium-cli", "jwts")
 
 	err = os.MkdirAll(dir, 0o755)
 	if err != nil {


### PR DESCRIPTION
## Summary
Add commands:

```bash
pomerium-cli cache clear
pomerium-cli cache location
```

## Related issues
Fixes https://github.com/pomerium/cli/issues/279


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
