### PR TITLE
creating tests for files in the cmd directory

### DIFF
--- a/cmd/pomerium-cli/cache_test.go
+++ b/cmd/pomerium-cli/cache_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// creating Mock Cache operations
+type MockCache struct {
+	mock.Mock
+}
+
+// mock func for cache.ExecCredentialsPath()
+func (m *MockCache) ExecCredentialsPath() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func TestClearAllCachedCredentials(t *testing.T) {
+	filePath := t.TempDir()
+	//mock object
+	mockCache := new(MockCache)
+
+	//set up dir expectation for ExecCredentialsPath
+	mockCache.On(" ExecCredentialsPath").Return(filePath+"/tmp/cache", nil)
+	_, err := os.Create(filePath + "/tmp/cache/file1.json")
+	if err != nil {
+		t.Log(err)
+		return
+	}
+	_, err = os.Create(filePath + "/tmp/cache/file2.json")
+	if err != nil {
+		t.Log(err)
+		return
+	}
+
+	err = clearAllCachedCredentials()
+	if err != nil {
+		t.Log(err)
+		return
+	}
+
+	// Verify that the cache directory is empty
+	dir, err := os.Open(filePath + "/tmp/cache")
+	assert.NoError(t, err)
+	defer dir.Close()
+
+	files, err := dir.Readdir(0)
+	assert.Error(t, err)
+	assert.Equal(t, 0, len(files))
+}
+
+func TestCachedCredentialPath(t *testing.T) {
+	//machine filepath name declared when running tests
+	pcPath := "/home/dell/.cache"
+	Testservers := []struct {
+		Name            string
+		ServerURL       string
+		expectedfileStr string
+	}{
+		{
+			Name:            "Oauth2 Server",
+			ServerURL:       "https://oauth.example.com/token",
+			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/69f5783b7ea001d28057a878dabcd152dbb53d8f4a4292d627fccb37d0a599c9.json", pcPath),
+		},
+		{
+			Name:            "LADP server",
+			ServerURL:       "ldap://ldap.example.com",
+			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/7395f94f936821c8762d36f9e2a2f9d08019615d902fbbab66734e865bc7ffdb.json", pcPath),
+		},
+		{
+			Name:            "Active Directory Server",
+			ServerURL:       "ldap://ad.example.com",
+			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/14f8a8115a66dcf32c1f1cd19afc1e3ac067355cf49ffe7c9b4070f0981cfeb6.json", pcPath),
+		},
+		{
+			Name:            "SAML Authentication Server",
+			ServerURL:       "https://saml.example.com/auth",
+			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/63e6533a0b622bbf900374505a0cfc72a4316687118e61a5f379ae0518a8cf84.json", pcPath),
+		},
+		{
+			Name:            "OpenID Connect Server",
+			ServerURL:       "https://openid.example.com/auth",
+			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/d43f430a0d22f9fa76aca8d30d02b4d93050f8f4031835dd67efe28ddccd80c0.json", pcPath),
+		},
+		{
+			Name:            "JWT Authentication Server",
+			ServerURL:       "https://jwt.example.com/auth",
+			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/b0b5d8589c64e2b7d5d7646fb9f0464d40196eb203efd37fda5e02d57cbaf5f5.json", pcPath),
+		},
+	}
+	for _, tc := range Testservers {
+		t.Run(tc.Name, func(t *testing.T) {
+			actualfileStr, err := cachedCredentialPath(tc.ServerURL)
+			if err != nil {
+				t.Log(err)
+				return
+			}
+			assert.NotNil(t, actualfileStr)
+			assert.Equal(t, tc.expectedfileStr, actualfileStr)
+		})
+	}
+}
+
+func TestClearCachedCredential(t *testing.T) {
+	pcPath := "/home/dell/.cache"
+	filepath := t.TempDir()
+	testCases := []struct {
+		Name      string
+		ServerURL string
+		CredFile  string
+	}{
+		{
+			Name:      "Token Authentication Server",
+			ServerURL: "https://auth.example.com/token",
+			CredFile:  filepath + fmt.Sprintf("%s/pomerium-cli/exec-credential/9a5e6376e10c7336bf32ad0be076c12909c44dd460c13110cf0c9b76eab85d51.json", pcPath),
+		},
+		{
+			Name:      "Oauth1 Server",
+			ServerURL: "https://oauth1.example.com/access_token",
+			CredFile:  filepath + fmt.Sprintf("%s/pomerium-cli/exec-credential/8cf70b03e5a6986f71a885f91bdf4e55e787b90a04457e05c7a8d02e6ff38163.json", pcPath),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			err := clearCachedCredential(tc.ServerURL)
+			if err != nil {
+				t.Log("unable to clear cached credentials:", err)
+				return
+			}
+			//ensure cachePath are cleared
+			dir, err := os.Open(filepath + tc.CredFile)
+			assert.NoError(t, err)
+			defer dir.Close()
+
+			files, err := dir.ReadDir(0)
+			assert.Error(t, err)
+			assert.Equal(t, 0, len(files))
+		})
+
+	}
+}

--- a/cmd/pomerium-cli/cache_test.go
+++ b/cmd/pomerium-cli/cache_test.go
@@ -1,113 +1,52 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
-// creating Mock Cache operations
-type MockCache struct {
-	mock.Mock
-}
-
-// mock func for cache.ExecCredentialsPath()
-func (m *MockCache) ExecCredentialsPath() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func TestClearAllCachedCredentials(t *testing.T) {
-	filePath := t.TempDir()
-	//mock object
-	mockCache := new(MockCache)
-
-	//set up dir expectation for ExecCredentialsPath
-	mockCache.On(" ExecCredentialsPath").Return(filePath+"/tmp/cache", nil)
-	_, err := os.Create(filePath + "/tmp/cache/file1.json")
-	if err != nil {
-		t.Log(err)
-		return
-	}
-	_, err = os.Create(filePath + "/tmp/cache/file2.json")
-	if err != nil {
-		t.Log(err)
-		return
-	}
-
-	err = clearAllCachedCredentials()
-	if err != nil {
-		t.Log(err)
-		return
-	}
-
-	// Verify that the cache directory is empty
-	dir, err := os.Open(filePath + "/tmp/cache")
-	assert.NoError(t, err)
-	defer dir.Close()
-
-	files, err := dir.Readdir(0)
-	assert.Error(t, err)
-	assert.Equal(t, 0, len(files))
-}
-
 func TestCachedCredentialPath(t *testing.T) {
-	//machine filepath name declared when running tests
-	pcPath := "/home/dell/.cache"
 	Testservers := []struct {
-		Name            string
-		ServerURL       string
-		expectedfileStr string
+		Name      string
+		ServerURL string
 	}{
 		{
-			Name:            "Oauth2 Server",
-			ServerURL:       "https://oauth.example.com/token",
-			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/69f5783b7ea001d28057a878dabcd152dbb53d8f4a4292d627fccb37d0a599c9.json", pcPath),
+			Name:      "Oauth2 Server",
+			ServerURL: "https://oauth.example.com/token",
 		},
 		{
-			Name:            "LADP server",
-			ServerURL:       "ldap://ldap.example.com",
-			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/7395f94f936821c8762d36f9e2a2f9d08019615d902fbbab66734e865bc7ffdb.json", pcPath),
+			Name:      "LADP server",
+			ServerURL: "ldap://ldap.example.com",
 		},
 		{
-			Name:            "Active Directory Server",
-			ServerURL:       "ldap://ad.example.com",
-			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/14f8a8115a66dcf32c1f1cd19afc1e3ac067355cf49ffe7c9b4070f0981cfeb6.json", pcPath),
+			Name:      "Active Directory Server",
+			ServerURL: "ldap://ad.example.com",
 		},
 		{
-			Name:            "SAML Authentication Server",
-			ServerURL:       "https://saml.example.com/auth",
-			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/63e6533a0b622bbf900374505a0cfc72a4316687118e61a5f379ae0518a8cf84.json", pcPath),
+			Name:      "SAML Authentication Server",
+			ServerURL: "https://saml.example.com/auth",
 		},
 		{
-			Name:            "OpenID Connect Server",
-			ServerURL:       "https://openid.example.com/auth",
-			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/d43f430a0d22f9fa76aca8d30d02b4d93050f8f4031835dd67efe28ddccd80c0.json", pcPath),
+			Name:      "OpenID Connect Server",
+			ServerURL: "https://openid.example.com/auth",
 		},
 		{
-			Name:            "JWT Authentication Server",
-			ServerURL:       "https://jwt.example.com/auth",
-			expectedfileStr: fmt.Sprintf("%s/pomerium-cli/exec-credential/b0b5d8589c64e2b7d5d7646fb9f0464d40196eb203efd37fda5e02d57cbaf5f5.json", pcPath),
+			Name:      "JWT Authentication Server",
+			ServerURL: "https://jwt.example.com/auth",
 		},
 	}
 	for _, tc := range Testservers {
 		t.Run(tc.Name, func(t *testing.T) {
 			actualfileStr, err := cachedCredentialPath(tc.ServerURL)
-			if err != nil {
-				t.Log(err)
-				return
-			}
+			assert.NoError(t, err)
 			assert.NotNil(t, actualfileStr)
-			assert.Equal(t, tc.expectedfileStr, actualfileStr)
 		})
 	}
 }
 
 func TestClearCachedCredential(t *testing.T) {
-	pcPath := "/home/dell/.cache"
 	filepath := t.TempDir()
 	testCases := []struct {
 		Name      string
@@ -117,12 +56,12 @@ func TestClearCachedCredential(t *testing.T) {
 		{
 			Name:      "Token Authentication Server",
 			ServerURL: "https://auth.example.com/token",
-			CredFile:  filepath + fmt.Sprintf("%s/pomerium-cli/exec-credential/9a5e6376e10c7336bf32ad0be076c12909c44dd460c13110cf0c9b76eab85d51.json", pcPath),
+			CredFile:  "/pomerium-cli/exec-credential/9a5e6376e10c7336bf32ad0be076c12909c44dd460c13110cf0c9b76eab85d51.json",
 		},
 		{
 			Name:      "Oauth1 Server",
 			ServerURL: "https://oauth1.example.com/access_token",
-			CredFile:  filepath + fmt.Sprintf("%s/pomerium-cli/exec-credential/8cf70b03e5a6986f71a885f91bdf4e55e787b90a04457e05c7a8d02e6ff38163.json", pcPath),
+			CredFile:  "/pomerium-cli/exec-credential/8cf70b03e5a6986f71a885f91bdf4e55e787b90a04457e05c7a8d02e6ff38163.json",
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/pomerium-cli/databroker_test.go
+++ b/cmd/pomerium-cli/databroker_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDBCmdParse(t *testing.T) {
+	cmd := &dbCmd{
+		serviceURL: "https://example.com:8443",
+	}
+	err := cmd.parse(nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "databroker", cmd.ServiceName)
+	expectedURL, _ := url.Parse("https://example.com:8443")
+	assert.Equal(t, expectedURL, cmd.Address)
+}

--- a/cmd/pomerium-cli/kubernetes_test.go
+++ b/cmd/pomerium-cli/kubernetes_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKubernetesFlushCredentialsCmd(t *testing.T) {
+	t.Run("TestK8slushCredentialsCmd", func(t *testing.T) {
+		// Capture stdout to a buffer
+		var stdoutBuf bytes.Buffer
+		cmd := kubernetesFlushCredentialsCmd
+		cmd.SetOutput(&stdoutBuf)
+
+		args := []string{"k8s", "http://k8s/example.com"}
+		cmd.SetArgs(args)
+
+		// Execute the command
+		err := cmd.Execute()
+		assert.NoError(t, err)
+
+		actualOutput := stdoutBuf.String()
+		assert.NotNil(t, actualOutput)
+
+	})
+}
+
+func TestParseToken(t *testing.T) {
+	rawjwt := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	expectedExecCred := &ExecCredential{
+		TypeMeta: TypeMeta{
+			APIVersion: "client.authentication.k8s.io/v1beta1",
+			Kind:       "ExecCredential",
+		},
+		Status: &ExecCredentialStatus{
+			Token: "Pomerium-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+		},
+	}
+
+	execCred, err := parseToken(rawjwt)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedExecCred.TypeMeta, execCred.TypeMeta)
+	assert.Equal(t, expectedExecCred.Status.Token, execCred.Status.Token)
+	// Check if ExpirationTimestamp is set within a reasonable range.
+	assert.WithinDuration(t, time.Now().Add(time.Hour), execCred.Status.ExpirationTimestamp, time.Second)
+}
+
+func TestPrintCreds(t *testing.T) {
+	testCreds := &ExecCredential{
+		TypeMeta: TypeMeta{
+			APIVersion: "client.authentication.k8s.io/v1beta1",
+			Kind:       "ExecCredential",
+		},
+	}
+	printCreds(testCreds)
+}

--- a/cmd/pomerium-cli/proxy_test.go
+++ b/cmd/pomerium-cli/proxy_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTCPTunnel(t *testing.T) {
+	tests := []struct {
+		Name                string
+		DstHost             string
+		SpecificPomeriumURL string
+		ExpectedError       string
+	}{
+		{
+			Name:                "Valid URL",
+			DstHost:             "example.com:443",
+			SpecificPomeriumURL: "https://pomerium.example.com",
+			ExpectedError:       "",
+		},
+		{
+			Name:                "Invalid Destination",
+			DstHost:             "invalid-host",
+			SpecificPomeriumURL: "https://pomerium.example.com",
+			ExpectedError:       "invalid destination",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			tunnel, err := newTCPTunnel(tc.DstHost, tc.SpecificPomeriumURL)
+
+			if tc.ExpectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.ExpectedError)
+				assert.Nil(t, tunnel)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, tunnel)
+			}
+
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/zeebo/blake3 v0.2.3 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyh
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

The existing implementation here contains unit test codes for different files in the `cmd` directory


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
