### PR TITLE
kubernetes: verify cached bearer tokens

### DIFF
--- a/authclient/authclient.go
+++ b/authclient/authclient.go
@@ -30,7 +30,7 @@ func New(options ...Option) *AuthClient {
 func (client *AuthClient) CheckBearerToken(ctx context.Context, serverURL *url.URL, bearerToken string) error {
 	browserURL := getBrowserURL(serverURL)
 	dst := browserURL.ResolveReference(&url.URL{
-		Path: "/api",
+		Path: "/livez",
 	})
 
 	req, err := http.NewRequest("GET", dst.String(), nil)

--- a/cmd/pomerium-cli/cache.go
+++ b/cmd/pomerium-cli/cache.go
@@ -110,7 +110,7 @@ func loadCachedCredential(serverURL string) (*ExecCredential, error) {
 	}
 
 	ts := creds.Status.ExpirationTimestamp
-	if ts.IsZero() || ts.Before(time.Now()) {
+	if !ts.IsZero() && ts.Before(time.Now()) {
 		_ = os.Remove(fn)
 		return nil, errors.New("expired")
 	}

--- a/cmd/pomerium-cli/kubernetes.go
+++ b/cmd/pomerium-cli/kubernetes.go
@@ -106,9 +106,9 @@ func parseToken(rawjwt string) (*ExecCredential, error) {
 		return nil, err
 	}
 
-	expiresAt := time.Unix(claims.Expiry, 0)
-	if claims.Expiry == 0 {
-		expiresAt = time.Now().Add(time.Hour)
+	var expiresAt time.Time
+	if claims.Expiry != 0 {
+		expiresAt = time.Unix(claims.Expiry, 0)
 	}
 
 	return &ExecCredential{


### PR DESCRIPTION
## Summary
Currently we rely on the expiration timestamp in the cached credentials to know when they need to be refreshed. This PR updates the code to not set the expiration timestamp at all if its not set in the JWT, and to always verify the JWT by attempting to access `/api` with the token. If access fails we assume the credentials are invalid.

## Related issues
- https://github.com/pomerium/internal/issues/1983


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
