### PR TITLE
tcptunnel: rename to tunnel

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -9,7 +9,7 @@ import (
 	"github.com/golang/groupcache/lru"
 
 	pb "github.com/pomerium/cli/proto"
-	"github.com/pomerium/cli/tcptunnel"
+	"github.com/pomerium/cli/tunnel"
 )
 
 // ConfigProvider provides interface to the configuration persistence
@@ -35,9 +35,9 @@ type ListenerStatus interface {
 	SetListenerError(id string, err error) error
 }
 
-// Tunnel is abstraction over tcptunnel.Tunnel to allow mocking
+// Tunnel is abstraction over tunnel.Tunnel to allow mocking
 type Tunnel interface {
-	Run(context.Context, io.ReadWriter, tcptunnel.TunnelEvents) error
+	Run(context.Context, io.ReadWriter, tunnel.EventSink) error
 }
 
 // Server implements both config and listener interfaces

--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/pomerium/cli/certstore"
 	pb "github.com/pomerium/cli/proto"
-	"github.com/pomerium/cli/tcptunnel"
+	"github.com/pomerium/cli/tunnel"
 )
 
 func newTunnel(conn *pb.Connection, browserCmd, serviceAccount, serviceAccountFile string) (Tunnel, string, error) {
@@ -27,7 +27,7 @@ func newTunnel(conn *pb.Connection, browserCmd, serviceAccount, serviceAccountFi
 		listenAddr = *conn.ListenAddr
 	}
 
-	destinationAddr, proxyURL, err := tcptunnel.ParseURLs(conn.GetRemoteAddr(), conn.GetPomeriumUrl())
+	destinationAddr, proxyURL, err := tunnel.ParseURLs(conn.GetRemoteAddr(), conn.GetPomeriumUrl())
 	if err != nil {
 		return nil, "", err
 	}
@@ -40,13 +40,13 @@ func newTunnel(conn *pb.Connection, browserCmd, serviceAccount, serviceAccountFi
 		}
 	}
 
-	return tcptunnel.New(
-		tcptunnel.WithDestinationHost(destinationAddr),
-		tcptunnel.WithProxyHost(proxyURL.Host),
-		tcptunnel.WithServiceAccount(serviceAccount),
-		tcptunnel.WithServiceAccountFile(serviceAccountFile),
-		tcptunnel.WithTLSConfig(tlsCfg),
-		tcptunnel.WithBrowserCommand(browserCmd),
+	return tunnel.New(
+		tunnel.WithDestinationHost(destinationAddr),
+		tunnel.WithProxyHost(proxyURL.Host),
+		tunnel.WithServiceAccount(serviceAccount),
+		tunnel.WithServiceAccountFile(serviceAccountFile),
+		tunnel.WithTLSConfig(tlsCfg),
+		tunnel.WithBrowserCommand(browserCmd),
 	), listenAddr, nil
 }
 

--- a/cmd/pomerium-cli/proxy.go
+++ b/cmd/pomerium-cli/proxy.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 
-	"github.com/pomerium/cli/tcptunnel"
+	"github.com/pomerium/cli/tunnel"
 )
 
 var proxyCmdOptions struct {
@@ -100,7 +100,7 @@ func makeDomainRegexes() ([]*regexp.Regexp, error) {
 	return domainRegexes, nil
 }
 
-func newTCPTunnel(dstHost string, specificPomeriumURL string) (*tcptunnel.Tunnel, error) {
+func newTCPTunnel(dstHost string, specificPomeriumURL string) (*tunnel.Tunnel, error) {
 	dstHostname, dstPort, err := net.SplitHostPort(dstHost)
 	if err != nil {
 		return nil, fmt.Errorf("invalid destination: %w", err)
@@ -138,12 +138,12 @@ func newTCPTunnel(dstHost string, specificPomeriumURL string) (*tcptunnel.Tunnel
 		}
 	}
 
-	return tcptunnel.New(
-		tcptunnel.WithDestinationHost(net.JoinHostPort(dstHostname, dstPort)),
-		tcptunnel.WithProxyHost(pomeriumURL.Host),
-		tcptunnel.WithServiceAccount(serviceAccountOptions.serviceAccount),
-		tcptunnel.WithServiceAccountFile(serviceAccountOptions.serviceAccountFile),
-		tcptunnel.WithTLSConfig(tlsConfig),
+	return tunnel.New(
+		tunnel.WithDestinationHost(net.JoinHostPort(dstHostname, dstPort)),
+		tunnel.WithProxyHost(pomeriumURL.Host),
+		tunnel.WithServiceAccount(serviceAccountOptions.serviceAccount),
+		tunnel.WithServiceAccountFile(serviceAccountOptions.serviceAccountFile),
+		tunnel.WithTLSConfig(tlsConfig),
 	), nil
 }
 
@@ -165,7 +165,7 @@ func hijackProxyConnect(req *http.Request, client net.Conn, ctx *goproxy.ProxyCt
 		log.Error().Err(err).Msg("Failed to send response to client")
 		return
 	}
-	if err := tun.Run(req.Context(), client, tcptunnel.DiscardEvents()); err != nil {
+	if err := tun.Run(req.Context(), client, tunnel.DiscardEvents()); err != nil {
 		log.Error().Err(err).Msg("Failed to run TCP tunnel")
 	}
 }

--- a/cmd/pomerium-cli/tcp.go
+++ b/cmd/pomerium-cli/tcp.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/pomerium/cli/tcptunnel"
+	"github.com/pomerium/cli/tunnel"
 )
 
 var tcpCmdOptions struct {
@@ -36,7 +36,7 @@ var tcpCmd = &cobra.Command{
 	Short: "creates a TCP tunnel through Pomerium",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		destinationAddr, proxyURL, err := tcptunnel.ParseURLs(args[0], tcpCmdOptions.pomeriumURL)
+		destinationAddr, proxyURL, err := tunnel.ParseURLs(args[0], tcpCmdOptions.pomeriumURL)
 		if err != nil {
 			return err
 		}
@@ -57,17 +57,17 @@ var tcpCmd = &cobra.Command{
 			cancel()
 		}()
 
-		tun := tcptunnel.New(
-			tcptunnel.WithBrowserCommand(browserOptions.command),
-			tcptunnel.WithDestinationHost(destinationAddr),
-			tcptunnel.WithProxyHost(proxyURL.Host),
-			tcptunnel.WithServiceAccount(serviceAccountOptions.serviceAccount),
-			tcptunnel.WithServiceAccountFile(serviceAccountOptions.serviceAccountFile),
-			tcptunnel.WithTLSConfig(tlsConfig),
+		tun := tunnel.New(
+			tunnel.WithBrowserCommand(browserOptions.command),
+			tunnel.WithDestinationHost(destinationAddr),
+			tunnel.WithProxyHost(proxyURL.Host),
+			tunnel.WithServiceAccount(serviceAccountOptions.serviceAccount),
+			tunnel.WithServiceAccountFile(serviceAccountOptions.serviceAccountFile),
+			tunnel.WithTLSConfig(tlsConfig),
 		)
 
 		if tcpCmdOptions.listen == "-" {
-			err = tun.Run(ctx, readWriter{Reader: os.Stdin, Writer: os.Stdout}, tcptunnel.DiscardEvents())
+			err = tun.Run(ctx, readWriter{Reader: os.Stdin, Writer: os.Stdout}, tunnel.DiscardEvents())
 		} else {
 			err = tun.RunListener(ctx, tcpCmdOptions.listen)
 		}

--- a/tunnel/config.go
+++ b/tunnel/config.go
@@ -1,4 +1,4 @@
-package tcptunnel
+package tunnel
 
 import (
 	"crypto/tls"

--- a/tunnel/events.go
+++ b/tunnel/events.go
@@ -1,11 +1,11 @@
-package tcptunnel
+package tunnel
 
 import (
 	"context"
 )
 
-// TunnelEvents is used to notify on the tunnel state transition
-type TunnelEvents interface {
+// EventSink is used to notify on the tunnel state transition
+type EventSink interface {
 	// OnConnecting is called when listener is accepting a new connection from client
 	OnConnecting(context.Context)
 	// OnConnected is called when a connection is successfully
@@ -19,22 +19,22 @@ type TunnelEvents interface {
 }
 
 // DiscardEvents returns a broadcaster that discards all events
-func DiscardEvents() TunnelEvents {
+func DiscardEvents() EventSink {
 	return discardEvents{}
 }
 
 type discardEvents struct{}
 
 // OnConnecting is called when listener is accepting a new connection from client
-func (d discardEvents) OnConnecting(_ context.Context) {}
+func (discardEvents) OnConnecting(_ context.Context) {}
 
 // OnConnected is called when a connection is successfully
 // established to the remote destination via pomerium proxy
-func (d discardEvents) OnConnected(_ context.Context) {}
+func (discardEvents) OnConnected(_ context.Context) {}
 
 // OnAuthRequired is called after listener accepted a new connection from client,
 // but has to perform user authentication first
-func (d discardEvents) OnAuthRequired(_ context.Context, _ string) {}
+func (discardEvents) OnAuthRequired(_ context.Context, _ string) {}
 
 // OnDisconnected is called when connection to client was closed
-func (d discardEvents) OnDisconnected(_ context.Context, _ error) {}
+func (discardEvents) OnDisconnected(_ context.Context, _ error) {}

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -1,4 +1,4 @@
-package tcptunnel
+package tunnel
 
 import (
 	"bufio"

--- a/tunnel/urls.go
+++ b/tunnel/urls.go
@@ -1,4 +1,4 @@
-package tcptunnel
+package tunnel
 
 import (
 	"fmt"

--- a/tunnel/urls_test.go
+++ b/tunnel/urls_test.go
@@ -1,4 +1,4 @@
-package tcptunnel
+package tunnel
 
 import (
 	"errors"


### PR DESCRIPTION
## Summary
In preparation for future changes, rename `tcptunnel` to `tunnel`.

## Related issues
- #466 


## Checklist

- [x] reference any related issues 
- [x] updated unit tests 
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
