### PR TITLE
http2 connect support

### DIFF
--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -162,7 +162,6 @@ func tunnelAcceptLoop(ctx context.Context, id string, li net.Listener, tun Tunne
 			if err != nil {
 				log.Printf("error serving local connection %s: %v\n", id, err)
 			}
-			cEvt.OnDisconnected(ctx, err)
 		}(c)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.29.0
+	golang.org/x/net v0.30.0
 	golang.org/x/sync v0.9.0
 	golang.org/x/sys v0.27.0
 	google.golang.org/grpc v1.68.0
@@ -57,7 +58,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/mod v0.20.0 // indirect
-	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/text v0.20.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 // indirect

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -2,15 +2,12 @@
 package tunnel
 
 import (
-	"bufio"
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net"
-	"net/http"
 	"net/url"
 	"time"
 
@@ -18,6 +15,11 @@ import (
 
 	"github.com/pomerium/cli/authclient"
 	"github.com/pomerium/cli/jwt"
+)
+
+var (
+	errUnavailable     = errors.New("unavailable")
+	errUnauthenticated = errors.New("unauthenticated")
 )
 
 // A Tunnel represents a TCP tunnel over HTTP Connect.
@@ -106,121 +108,40 @@ func (tun *Tunnel) Run(ctx context.Context, local io.ReadWriter, eventSink Event
 }
 
 func (tun *Tunnel) run(ctx context.Context, eventSink EventSink, local io.ReadWriter, rawJWT string, retryCount int) error {
-	eventSink.OnConnecting(ctx)
-
-	hdr := http.Header{}
-	if rawJWT != "" {
-		hdr.Set("Authorization", "Pomerium "+rawJWT)
-	}
-
-	req := (&http.Request{
-		Method: "CONNECT",
-		URL:    &url.URL{Opaque: tun.cfg.dstHost},
-		Host:   tun.cfg.dstHost,
-		Header: hdr,
-	}).WithContext(ctx)
-
-	var remote net.Conn
-	var err error
-	if tun.cfg.tlsConfig != nil {
-		remote, err = (&tls.Dialer{Config: tun.cfg.tlsConfig}).DialContext(ctx, "tcp", tun.cfg.proxyHost)
-	} else {
-		remote, err = (&net.Dialer{}).DialContext(ctx, "tcp", tun.cfg.proxyHost)
-	}
-	if err != nil {
-		return fmt.Errorf("failed to establish connection to proxy: %w", err)
-	}
-	defer func() {
-		_ = remote.Close()
-		log.Println("connection closed")
-	}()
-	if done := ctx.Done(); done != nil {
-		go func() {
-			<-done
-			_ = remote.Close()
-		}()
-	}
-
-	err = req.Write(remote)
-	if err != nil {
-		return err
-	}
-
-	br := bufio.NewReader(remote)
-	res, err := http.ReadResponse(br, req)
-	if err != nil {
-		return fmt.Errorf("failed to read HTTP response: %w", err)
-	}
-	defer func() {
-		_ = res.Body.Close()
-	}()
-	switch res.StatusCode {
-	case http.StatusOK:
-	case http.StatusServiceUnavailable:
+	err := (&http1tunnel{cfg: tun.cfg}).TunnelTCP(ctx, eventSink, local, rawJWT)
+	if errors.Is(err, errUnavailable) {
 		// don't delete the JWT if we get a service unavailable
-		return fmt.Errorf("invalid http response code: %s", res.Status)
-	case http.StatusMovedPermanently,
-		http.StatusFound,
-		http.StatusTemporaryRedirect,
-		http.StatusPermanentRedirect:
-		if retryCount == 0 {
-			_ = remote.Close()
-
-			serverURL := &url.URL{
-				Scheme: "http",
-				Host:   tun.cfg.proxyHost,
-			}
-			if tun.cfg.tlsConfig != nil {
-				serverURL.Scheme = "https"
-			}
-
-			rawJWT, err = tun.auth.GetJWT(ctx, serverURL, func(authURL string) { eventSink.OnAuthRequired(ctx, authURL) })
-			if err != nil {
-				return fmt.Errorf("failed to get authentication JWT: %w", err)
-			}
-
-			err = tun.cfg.jwtCache.StoreJWT(tun.jwtCacheKey(), rawJWT)
-			if err != nil {
-				return fmt.Errorf("failed to store JWT: %w", err)
-			}
-
-			return tun.run(ctx, eventSink, local, rawJWT, retryCount+1)
-		}
-		fallthrough
-	default:
-		_ = tun.cfg.jwtCache.DeleteJWT(tun.jwtCacheKey())
-		return fmt.Errorf("invalid http response code: %d", res.StatusCode)
-	}
-
-	log.Println("connection established")
-	eventSink.OnConnected(ctx)
-
-	errc := make(chan error, 2)
-	go func() {
-		_, err := io.Copy(remote, local)
-		errc <- err
-	}()
-	remoteReader := deBuffer(br, remote)
-	go func() {
-		_, err := io.Copy(local, remoteReader)
-		errc <- err
-	}()
-
-	select {
-	case err := <-errc:
 		return err
-	case <-ctx.Done():
-		return nil
+	} else if errors.Is(err, errUnauthenticated) && retryCount == 0 {
+		serverURL := &url.URL{
+			Scheme: "http",
+			Host:   tun.cfg.proxyHost,
+		}
+		if tun.cfg.tlsConfig != nil {
+			serverURL.Scheme = "https"
+		}
+
+		rawJWT, err = tun.auth.GetJWT(ctx, serverURL, func(authURL string) {
+			eventSink.OnAuthRequired(ctx, authURL)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get authentication JWT: %w", err)
+		}
+
+		err = tun.cfg.jwtCache.StoreJWT(tun.jwtCacheKey(), rawJWT)
+		if err != nil {
+			return fmt.Errorf("failed to store JWT: %w", err)
+		}
+
+		return tun.run(ctx, eventSink, local, rawJWT, retryCount+1)
+	} else if err != nil {
+		_ = tun.cfg.jwtCache.DeleteJWT(tun.jwtCacheKey())
+		return err
 	}
+
+	return nil
 }
 
 func (tun *Tunnel) jwtCacheKey() string {
 	return fmt.Sprintf("%s|%v", tun.cfg.proxyHost, tun.cfg.tlsConfig != nil)
-}
-
-func deBuffer(br *bufio.Reader, underlying io.Reader) io.Reader {
-	if br.Buffered() == 0 {
-		return underlying
-	}
-	return io.MultiReader(io.LimitReader(br, int64(br.Buffered())), underlying)
 }

--- a/tunnel/tunnel_http1.go
+++ b/tunnel/tunnel_http1.go
@@ -1,0 +1,117 @@
+package tunnel
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+)
+
+type http1tunnel struct {
+	cfg *config
+}
+
+func (t *http1tunnel) TunnelTCP(
+	ctx context.Context,
+	eventSink EventSink,
+	local io.ReadWriter,
+	rawJWT string,
+) error {
+	eventSink.OnConnecting(ctx)
+
+	hdr := http.Header{}
+	if rawJWT != "" {
+		hdr.Set("Authorization", "Pomerium "+rawJWT)
+	}
+
+	req := (&http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{Opaque: t.cfg.dstHost},
+		Host:   t.cfg.dstHost,
+		Header: hdr,
+	}).WithContext(ctx)
+
+	var remote net.Conn
+	var err error
+	if t.cfg.tlsConfig != nil {
+		remote, err = (&tls.Dialer{Config: t.cfg.tlsConfig}).DialContext(ctx, "tcp", t.cfg.proxyHost)
+	} else {
+		remote, err = (&net.Dialer{}).DialContext(ctx, "tcp", t.cfg.proxyHost)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to establish connection to proxy: %w", err)
+	}
+	defer func() {
+		_ = remote.Close()
+		log.Println("connection closed")
+	}()
+	if done := ctx.Done(); done != nil {
+		go func() {
+			<-done
+			_ = remote.Close()
+		}()
+	}
+
+	err = req.Write(remote)
+	if err != nil {
+		return err
+	}
+
+	br := bufio.NewReader(remote)
+	res, err := http.ReadResponse(br, req)
+	if err != nil {
+		return fmt.Errorf("failed to read HTTP response: %w", err)
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+	case http.StatusServiceUnavailable:
+		return errUnavailable
+	case http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect:
+		return errUnauthenticated
+	default:
+		return fmt.Errorf("invalid http response code: %d", res.StatusCode)
+	}
+
+	log.Println("connection established")
+	eventSink.OnConnected(ctx)
+
+	errc := make(chan error, 2)
+	go func() {
+		_, err := io.Copy(remote, local)
+		errc <- err
+	}()
+	remoteReader := deBuffer(br, remote)
+	go func() {
+		_, err := io.Copy(local, remoteReader)
+		errc <- err
+	}()
+
+	select {
+	case err = <-errc:
+	case <-ctx.Done():
+		err = context.Cause(ctx)
+	}
+
+	eventSink.OnDisconnected(ctx, err)
+
+	return err
+}
+
+func deBuffer(br *bufio.Reader, underlying io.Reader) io.Reader {
+	if br.Buffered() == 0 {
+		return underlying
+	}
+	return io.MultiReader(io.LimitReader(br, int64(br.Buffered())), underlying)
+}

--- a/tunnel/tunnel_http2.go
+++ b/tunnel/tunnel_http2.go
@@ -1,0 +1,101 @@
+package tunnel
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/http2"
+)
+
+type http2tunnel struct {
+	cfg *config
+}
+
+func (t *http2tunnel) TunnelTCP(
+	ctx context.Context,
+	eventSink EventSink,
+	local io.ReadWriter,
+	rawJWT string,
+) error {
+	eventSink.OnConnecting(ctx)
+
+	hdr := http.Header{}
+	if rawJWT != "" {
+		hdr.Set("Authorization", "Pomerium "+rawJWT)
+	}
+
+	if t.cfg.tlsConfig == nil {
+		return fmt.Errorf("%w: http2 requires TLS", errUnsupported)
+	}
+
+	cfg := t.cfg.tlsConfig.Clone()
+	cfg.NextProtos = []string{"h2"}
+
+	raw, err := (&tls.Dialer{Config: cfg}).DialContext(ctx, "tcp", t.cfg.proxyHost)
+	if err != nil {
+		return fmt.Errorf("failed to establish connection to proxy: %w", err)
+	}
+
+	remote, ok := raw.(*tls.Conn)
+	if !ok {
+		return fmt.Errorf("unexpected connection type returned from dial: %T", raw)
+	}
+
+	protocol := remote.ConnectionState().NegotiatedProtocol
+	if protocol != "h2" {
+		return fmt.Errorf("%w: unexpected TLS protocol: %s", errUnsupported, protocol)
+	}
+
+	cc, err := (&http2.Transport{}).NewClientConn(remote)
+	if err != nil {
+		return fmt.Errorf("failed to establish http2 connection: %w", err)
+	}
+
+	req := (&http.Request{
+		Method:        "CONNECT",
+		URL:           &url.URL{Opaque: t.cfg.dstHost},
+		Host:          t.cfg.dstHost,
+		Header:        hdr,
+		Body:          io.NopCloser(local),
+		ContentLength: -1,
+	}).WithContext(ctx)
+
+	res, err := cc.RoundTrip(req)
+	if err != nil {
+		return fmt.Errorf("error making http2 connect request: %w", err)
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+	case http.StatusServiceUnavailable:
+		return errUnavailable
+	case http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect:
+		return errUnauthenticated
+	default:
+		return fmt.Errorf("invalid http response code: %d", res.StatusCode)
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(local, res.Body)
+		errc <- err
+	}()
+
+	select {
+	case err = <-errc:
+	case <-ctx.Done():
+		err = context.Cause(ctx)
+	}
+
+	eventSink.OnDisconnected(ctx, err)
+
+	return err
+}

--- a/tunnel/tunnel_http2_test.go
+++ b/tunnel/tunnel_http2_test.go
@@ -1,0 +1,69 @@
+package tunnel
+
+import (
+	"context"
+	"crypto/tls"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTCPTunnelViaHTTP2(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	defer clearTimeout()
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !assert.Equal(t, "CONNECT", r.Method) {
+			return
+		}
+		if !assert.Equal(t, "Pomerium JWT", r.Header.Get("Authorization")) {
+			return
+		}
+		if !assert.Equal(t, "example.com:9999", r.Host) {
+			return
+		}
+
+		defer r.Body.Close()
+		w.WriteHeader(http.StatusOK)
+
+		buf := make([]byte, 4)
+		_, err := io.ReadFull(r.Body, buf)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{1, 2, 3, 4}, buf)
+
+		_, _ = w.Write([]byte{5, 6, 7, 8})
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+
+	c1, c2 := net.Pipe()
+	go func() {
+		_, _ = c1.Write([]byte{1, 2, 3, 4})
+	}()
+	go func() {
+		buf := make([]byte, 4)
+		_, err := io.ReadFull(c1, buf)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte{5, 6, 7, 8}, buf)
+		_ = c1.Close()
+	}()
+
+	tun := &http2tunnel{
+		getConfig(
+			WithDestinationHost("example.com:9999"),
+			WithProxyHost(srv.Listener.Addr().String()),
+			WithTLSConfig(&tls.Config{
+				InsecureSkipVerify: true,
+			}),
+		),
+	}
+	err := tun.TunnelTCP(ctx, DiscardEvents(), c2, "JWT")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
Add support for TCP tunneling over HTTP/2. If HTTP/2 is not available, we fallback to HTTP/1.

## Related issues
- #464 


## Checklist

- [x] reference any related issues 
- [x] updated unit tests 
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
