### PR TITLE
Refactor release workflow and add MSI build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,8 +114,9 @@ jobs:
         shell: bash
         run: |
           dotnet tool install --global wix
+          wix extension add -g WixToolset.UI.wixext
           msifile="pomerium-cli-windows-${{ matrix.arch.go }}.msi"
-          wix build -arch ${{ matrix.arch.wix }} -b bin\\${{ matrix.arch.go }} -d "version=${{ needs.metadata.outputs.versionNumber }}" -o "$msifile" msi/PomeriumCli.wxs
+          wix build -arch ${{ matrix.arch.wix }} -ext WixToolset.UI.wixext -b bin\\${{ matrix.arch.go }} -d "version=${{ needs.metadata.outputs.versionNumber }}" -o "$msifile" msi/PomeriumCli.wxs msi/WixUI_InstallDir_NoLicense.wxs
           hash=$(powershell "(Get-FileHash $msifile -Algorithm SHA256).Hash.ToLower()")
           echo 'checksums<<EOF' >> $GITHUB_OUTPUT
           echo "$hash $zipfile" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,8 +52,8 @@ jobs:
             -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
             ./cmd/pomerium-cli
 
-      - name: Build and archive
-        id: build
+      - name: Archive
+        id: archive
         run: |
           gtar czf pomerium-cli-darwin-${{ matrix.arch }}.tar.gz -C bin/${{ matrix.arch }} pomerium-cli
           echo 'checksums<<EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       versionFlags: ${{ steps.flags.outputs.versionFlags }}
+      versionNumber: ${{ steps.flags.outputs.versionNumber }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -26,6 +27,7 @@ jobs:
             "-X github.com/pomerium/cli/version.ProjectURL=https://www.pomerium.io"
           )
           echo "versionFlags=${ldflags[*]}" >> $GITHUB_OUTPUT
+          echo "versionNumber=$(echo ${{ github.event.release.tag_name }} | grep -o -P "\d+(?:\.\d+)*" || echo "1.0.0.0")" >> $GITHUB_OUTPUT
 
   build-macos:
     runs-on: macos-latest
@@ -70,7 +72,7 @@ jobs:
     needs: metadata
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: [{go: amd64, wix: x64}, {go: arm64, wix: arm64}]
     outputs:
       checksums: ${{ steps.build.outputs.checksums }}
     steps:
@@ -82,12 +84,17 @@ jobs:
         with:
           go-version: 1.23.x
 
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Build
         id: build
         shell: bash
         run: |
-          mkdir -p bin/${{ matrix.arch }}
-          GOARCH=${{ matrix.arch }} CGO_ENABLED=1 go build -o bin/${{ matrix.arch }} \
+          mkdir -p bin/${{ matrix.arch.go }}
+          GOARCH=${{ matrix.arch.go }} CGO_ENABLED=1 go build -o bin/${{ matrix.arch.go }} \
             -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
             ./cmd/pomerium-cli
 
@@ -95,9 +102,21 @@ jobs:
         id: archive
         shell: bash
         run: |
-          zipfile="pomerium-cli-windows-${{ matrix.arch }}.zip"
-          powershell "Compress-Archive -Path bin\\${{ matrix.arch }}\\\* -DestinationPath $zipfile"
+          zipfile="pomerium-cli-windows-${{ matrix.arch.go }}.zip"
+          powershell "Compress-Archive -Path bin\\${{ matrix.arch.go }}\\\* -DestinationPath $zipfile"
           hash=$(powershell "(Get-FileHash $zipfile -Algorithm SHA256).Hash.ToLower()")
+          echo 'checksums<<EOF' >> $GITHUB_OUTPUT
+          echo "$hash $zipfile" >> $GITHUB_OUTPUT
+          echo EOF >> $GITHUB_OUTPUT
+
+      - name: Build MSI
+        id: msi
+        shell: bash
+        run: |
+          dotnet tool install --global wix
+          msifile="pomerium-cli-windows-${{ matrix.arch.go }}.msi"
+          wix build -arch ${{ matrix.arch.wix }} -b bin\\${{ matrix.arch.go }} -d "version=${{ needs.metadata.outputs.versionNumber }}" -o "$msifile" msi/PomeriumCli.wxs
+          hash=$(powershell "(Get-FileHash $msifile -Algorithm SHA256).Hash.ToLower()")
           echo 'checksums<<EOF' >> $GITHUB_OUTPUT
           echo "$hash $zipfile" >> $GITHUB_OUTPUT
           echo EOF >> $GITHUB_OUTPUT
@@ -106,7 +125,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" pomerium-cli-windows-*.zip
+        run: gh release upload "${{ github.event.release.tag_name }}" pomerium-cli-windows-*.zip pomerium-cli-windows-*.msi
 
   goreleaser:
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,9 @@ jobs:
   build-macos:
     runs-on: macos-latest
     needs: metadata
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     outputs:
       checksums: ${{ steps.build.outputs.checksums }}
     steps:
@@ -41,18 +44,20 @@ jobs:
         with:
           go-version: 1.23.x
 
+      - name: Build
+        id: build
+        run: |
+          mkdir -p bin/${{ matrix.arch }}
+          GOARCH=${{ matrix.arch }} CGO_ENABLED=1 go build -o bin/${{ matrix.arch }} \
+            -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
+            ./cmd/pomerium-cli
+
       - name: Build and archive
         id: build
         run: |
+          gtar czf pomerium-cli-darwin-${{ matrix.arch }}.tar.gz -C bin/${{ matrix.arch }} pomerium-cli
           echo 'checksums<<EOF' >> $GITHUB_OUTPUT
-          for arch in amd64 arm64; do
-            mkdir -p bin/$arch
-            GOARCH=$arch CGO_ENABLED=1 go build -o bin/$arch \
-              -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
-              ./cmd/pomerium-cli
-            gtar czf pomerium-cli-darwin-$arch.tar.gz -C bin/$arch pomerium-cli
-            shasum -a 256 pomerium-cli-darwin-$arch.tar.gz >> $GITHUB_OUTPUT
-          done
+          shasum -a 256 pomerium-cli-darwin-${{ matrix.arch }}.tar.gz >> $GITHUB_OUTPUT
           echo EOF >> $GITHUB_OUTPUT
 
       - name: Upload to release
@@ -63,6 +68,9 @@ jobs:
   build-windows:
     runs-on: windows-latest
     needs: metadata
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     outputs:
       checksums: ${{ steps.build.outputs.checksums }}
     steps:
@@ -74,21 +82,24 @@ jobs:
         with:
           go-version: 1.23.x
 
-      - name: Build and archive
+      - name: Build
         id: build
         shell: bash
         run: |
+          mkdir -p bin/${{ matrix.arch }}
+          GOARCH=${{ matrix.arch }} CGO_ENABLED=1 go build -o bin/${{ matrix.arch }} \
+            -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
+            ./cmd/pomerium-cli
+
+      - name: Archive
+        id: archive
+        shell: bash
+        run: |
+          zipfile="pomerium-cli-windows-${{ matrix.arch }}.zip"
+          powershell "Compress-Archive -Path bin\\${{ matrix.arch }}\\\* -DestinationPath $zipfile"
+          hash=$(powershell "(Get-FileHash $zipfile -Algorithm SHA256).Hash.ToLower()")
           echo 'checksums<<EOF' >> $GITHUB_OUTPUT
-          for arch in amd64 arm64; do
-            mkdir -p bin/$arch
-            GOARCH=$arch CGO_ENABLED=1 go build -o bin/$arch \
-              -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
-              ./cmd/pomerium-cli
-            zipfile="pomerium-cli-windows-$arch.zip"
-            powershell "Compress-Archive -Path bin\\$arch\\\* -DestinationPath $zipfile"
-            hash=$(powershell "(Get-FileHash $zipfile -Algorithm SHA256).Hash.ToLower()")
-            echo "$hash  $zipfile" >> $GITHUB_OUTPUT
-          done
+          echo "$hash $zipfile" >> $GITHUB_OUTPUT
           echo EOF >> $GITHUB_OUTPUT
 
       - name: Upload to release

--- a/msi/PomeriumCli.wxs
+++ b/msi/PomeriumCli.wxs
@@ -1,10 +1,15 @@
-<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
     <Package UpgradeCode="0A602749-404A-4192-84F3-9A7BA9F93EA1" Language="1033"
         Manufacturer="Pomerium" Name="Pomerium CLI" Version="$(var.version)">
         <MajorUpgrade AllowSameVersionUpgrades="yes"
             DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
 
         <MediaTemplate EmbedCab="yes" />
+
+        <ui:WixUI
+            Id="WixUI_InstallDir_NoLicense"
+            InstallDirectory="INSTALLFOLDER"
+        />
 
         <Feature Id="PomeriumCliFeature">
             <ComponentRef Id="CliExecutable" />
@@ -13,7 +18,8 @@
         <StandardDirectory Id="ProgramFiles64Folder">
             <Directory Id="INSTALLFOLDER" Name="Pomerium\Pomerium CLI">
                 <Component Id="CliExecutable">
-                    <File Id="PomeriumCliExe" KeyPath="yes" Name="pomerium-cli.exe" Source="pomerium-cli.exe"></File>
+                    <File Id="PomeriumCliExe" KeyPath="yes" Name="pomerium-cli.exe"
+                        Source="pomerium-cli.exe"></File>
                 </Component>
             </Directory>
         </StandardDirectory>

--- a/msi/PomeriumCli.wxs
+++ b/msi/PomeriumCli.wxs
@@ -1,0 +1,21 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package UpgradeCode="0A602749-404A-4192-84F3-9A7BA9F93EA1" Language="1033"
+        Manufacturer="Pomerium" Name="Pomerium CLI" Version="$(var.version)">
+        <MajorUpgrade AllowSameVersionUpgrades="yes"
+            DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
+
+        <MediaTemplate EmbedCab="yes" />
+
+        <Feature Id="PomeriumCliFeature">
+            <ComponentRef Id="CliExecutable" />
+        </Feature>
+
+        <StandardDirectory Id="ProgramFiles64Folder">
+            <Directory Id="INSTALLFOLDER" Name="Pomerium\Pomerium CLI">
+                <Component Id="CliExecutable">
+                    <File Id="PomeriumCliExe" KeyPath="yes" Name="pomerium-cli.exe" Source="pomerium-cli.exe"></File>
+                </Component>
+            </Directory>
+        </StandardDirectory>
+    </Package>
+</Wix>

--- a/msi/WixUI_InstallDir_NoLicense.wxs
+++ b/msi/WixUI_InstallDir_NoLicense.wxs
@@ -1,0 +1,81 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<!-- Based on: https://github.com/wixtoolset/wix/blob/main/src/ext/UI/wixlib/WixUI_InstallDir.wxs -->
+
+<!--
+First-time install dialog sequence:
+ - WixUI_WelcomeDlg
+ - WixUI_InstallDirDlg
+ - WixUI_VerifyReadyDlg
+ - WixUI_DiskCostDlg
+
+Maintenance dialog sequence:
+ - WixUI_MaintenanceWelcomeDlg
+ - WixUI_MaintenanceTypeDlg
+ - WixUI_InstallDirDlg
+ - WixUI_VerifyReadyDlg
+
+Patch dialog sequence:
+ - WixUI_WelcomeDlg
+ - WixUI_VerifyReadyDlg
+
+-->
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <?foreach WIXUIARCH in X86;X64;A64 ?>
+    <Fragment>
+        <UI Id="WixUI_InstallDir_NoLicense_$(WIXUIARCH)">
+            <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath_$(WIXUIARCH)" Order="2" Condition="NOT WIXUI_DONTVALIDATEPATH" />
+        </UI>
+
+        <UIRef Id="WixUI_InstallDir_NoLicense" />
+    </Fragment>
+    <?endforeach?>
+
+    <Fragment>
+        <UI Id="file WixUI_InstallDir_NoLicense">
+            <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8" />
+            <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12" />
+            <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes" />
+
+            <Property Id="DefaultUIFont" Value="WixUI_Font_Normal" />
+
+            <DialogRef Id="BrowseDlg" />
+            <DialogRef Id="DiskCostDlg" />
+            <DialogRef Id="ErrorDlg" />
+            <DialogRef Id="FatalError" />
+            <DialogRef Id="FilesInUse" />
+            <DialogRef Id="MsiRMFilesInUse" />
+            <DialogRef Id="PrepareDlg" />
+            <DialogRef Id="ProgressDlg" />
+            <DialogRef Id="ResumeDlg" />
+            <DialogRef Id="UserExit" />
+            <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4" Condition="NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;" />
+
+            <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="999" />
+
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Condition="NOT Installed" />
+            <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Condition="Installed AND PATCH" />
+
+            <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3" Condition="NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID&lt;&gt;&quot;1&quot;" />
+            <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4" Condition="WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID=&quot;1&quot;" />
+            <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1" />
+            <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2" />
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="1" Condition="NOT Installed" />
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2" Condition="Installed AND NOT PATCH" />
+            <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2" Condition="Installed AND PATCH" />
+
+            <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg" />
+
+            <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg" />
+            <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg" />
+            <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg" />
+
+            <Property Id="ARPNOMODIFY" Value="1" />
+        </UI>
+
+        <UIRef Id="WixUI_Common" />
+    </Fragment>
+</Wix>


### PR DESCRIPTION
## Summary

This PR refactors the release workflow to use a matrix strategy and adds a step to build MSI packages for Windows.

- Instead of using a shell loop to build for ARM and x86 it uses the GitHub actions matrix feature to build both in parallel.
This makes the builds faster and easier to troubleshoot
- It separates the build and archive steps into two distinct steps to make it more clear and ease troubleshooting
- It adds a step that uses the Wix toolkit to build an MSI package for Windows. The MSI is very simple and will simply install the exe file in with the option for the user to change this `%ProgramFiles%\Pomerium\Pomerium CLI\`

## Related issues

None

## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
