### PR TITLE
tunnel: handle forbidden responses

### DIFF
--- a/tunnel/tunnel_http1.go
+++ b/tunnel/tunnel_http1.go
@@ -78,17 +78,9 @@ func (t *http1tunneler) TunnelTCP(
 		_ = res.Body.Close()
 	}()
 
-	switch res.StatusCode {
-	case http.StatusOK:
-	case http.StatusServiceUnavailable:
-		return errUnavailable
-	case http.StatusMovedPermanently,
-		http.StatusFound,
-		http.StatusTemporaryRedirect,
-		http.StatusPermanentRedirect:
-		return errUnauthenticated
-	default:
-		return fmt.Errorf("http/1: invalid http response code: %d", res.StatusCode)
+	err = httpStatusCodeToError(res.StatusCode)
+	if err != nil {
+		return err
 	}
 
 	eventSink.OnConnected(ctx)
@@ -180,17 +172,9 @@ func (t *http1tunneler) TunnelUDP(
 		_ = res.Body.Close()
 	}()
 
-	switch res.StatusCode {
-	case http.StatusOK:
-	case http.StatusServiceUnavailable:
-		return errUnavailable
-	case http.StatusMovedPermanently,
-		http.StatusFound,
-		http.StatusTemporaryRedirect,
-		http.StatusPermanentRedirect:
-		return errUnauthenticated
-	default:
-		return fmt.Errorf("http/1: invalid http response code: %d", res.StatusCode)
+	err = httpStatusCodeToError(res.StatusCode)
+	if err != nil {
+		return err
 	}
 
 	eventSink.OnConnected(ctx)

--- a/tunnel/tunnel_http2.go
+++ b/tunnel/tunnel_http2.go
@@ -77,17 +77,9 @@ func (t *http2tunneler) TunnelTCP(
 	}
 	defer res.Body.Close()
 
-	switch res.StatusCode {
-	case http.StatusOK:
-	case http.StatusServiceUnavailable:
-		return errUnavailable
-	case http.StatusMovedPermanently,
-		http.StatusFound,
-		http.StatusTemporaryRedirect,
-		http.StatusPermanentRedirect:
-		return errUnauthenticated
-	default:
-		return fmt.Errorf("http/2: invalid http response code: %d", res.StatusCode)
+	err = httpStatusCodeToError(res.StatusCode)
+	if err != nil {
+		return err
 	}
 
 	eventSink.OnConnected(ctx)

--- a/tunnel/tunnel_http3.go
+++ b/tunnel/tunnel_http3.go
@@ -68,17 +68,9 @@ func (t *http3tunneler) TunnelTCP(
 	}
 	defer res.Body.Close()
 
-	switch res.StatusCode {
-	case http.StatusOK:
-	case http.StatusServiceUnavailable:
-		return errUnavailable
-	case http.StatusMovedPermanently,
-		http.StatusFound,
-		http.StatusTemporaryRedirect,
-		http.StatusPermanentRedirect:
-		return errUnauthenticated
-	default:
-		return fmt.Errorf("http/3: invalid response code: %d", res.StatusCode)
+	err = httpStatusCodeToError(res.StatusCode)
+	if err != nil {
+		return err
 	}
 
 	eventSink.OnConnected(ctx)
@@ -167,17 +159,9 @@ func (t *http3tunneler) TunnelUDP(
 	}
 	defer res.Body.Close()
 
-	switch res.StatusCode {
-	case http.StatusOK:
-	case http.StatusServiceUnavailable:
-		return errUnavailable
-	case http.StatusMovedPermanently,
-		http.StatusFound,
-		http.StatusTemporaryRedirect,
-		http.StatusPermanentRedirect:
-		return errUnauthenticated
-	default:
-		return fmt.Errorf("http/3: invalid http response code: %d", res.StatusCode)
+	err = httpStatusCodeToError(res.StatusCode)
+	if err != nil {
+		return err
 	}
 
 	eventSink.OnConnected(ctx)


### PR DESCRIPTION
## Summary
Currently if a tunnel receives a `403` we will attempt to login again the next time the tunnel is created. This PR updates the code to not clear the JWT credentials on `403`s, since those credentials won't change if the user logs in again.

## Related issues
- https://linear.app/pomerium/issue/ENG-1834/udp-infinite-authentication-loop-instead-of-access-denied


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
