### PR TITLE
log probe request, disable redirects, disable http/2

### DIFF
--- a/cmd/pomerium-cli/main.go
+++ b/cmd/pomerium-cli/main.go
@@ -49,7 +49,15 @@ func signalContext() context.Context {
 }
 
 func setupLogger() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	log.Logger = log.Level(zerolog.InfoLevel)
+
+	// set the log level
+	if raw := os.Getenv("LOG_LEVEL"); raw != "" {
+		if lvl, err := zerolog.ParseLevel(raw); err == nil {
+			log.Logger = log.Logger.Level(lvl)
+		}
+	}
+
 	zerolog.DefaultContextLogger = &log.Logger
 }
 

--- a/internal/httputil/transport.go
+++ b/internal/httputil/transport.go
@@ -1,0 +1,71 @@
+package httputil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type loggingRoundTripper struct {
+	base      http.RoundTripper
+	logger    zerolog.Logger
+	customize []func(event *zerolog.Event) *zerolog.Event
+}
+
+func (l loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	res, err := l.base.RoundTrip(req)
+	statusCode := http.StatusInternalServerError
+	if res != nil {
+		statusCode = res.StatusCode
+	}
+
+	evt := l.logger.Debug().
+		Str("method", req.Method).
+		Str("authority", req.URL.Host).
+		Str("path", req.URL.Path).
+		Dur("duration", time.Since(start)).
+		Int("response-code", statusCode)
+	for _, f := range l.customize {
+		f(evt)
+	}
+
+	// if status code is not 200, log the body
+	if res != nil && statusCode/100 != 2 {
+		responseBody := make([]byte, 16*1024)
+		if n, r, e := peek(res.Body, responseBody); e == nil {
+			// replace the body so that the peek'd bytes can be re-read
+			res.Body = struct {
+				io.Reader
+				io.Closer
+			}{r, res.Body}
+			evt = evt.Str("response-body", string(responseBody[:n]))
+		} else {
+			panic(e)
+		}
+	}
+
+	evt.Msg("http-request")
+	return res, err
+}
+
+// NewLoggingRoundTripper creates a http.RoundTripper that will log requests.
+func NewLoggingRoundTripper(logger zerolog.Logger, base http.RoundTripper, customize ...func(event *zerolog.Event) *zerolog.Event) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return loggingRoundTripper{base: base, logger: logger, customize: customize}
+}
+
+func peek(r io.Reader, dst []byte) (n int, newReader io.Reader, err error) {
+	var tmp bytes.Buffer
+	n, err = io.TeeReader(r, &tmp).Read(dst)
+	if errors.Is(err, io.EOF) {
+		err = nil
+	}
+	return n, io.MultiReader(&tmp, r), err
+}

--- a/tunnel/tunnel_http1.go
+++ b/tunnel/tunnel_http1.go
@@ -47,7 +47,10 @@ func (t *http1tunneler) TunnelTCP(
 	var remote net.Conn
 	var err error
 	if t.cfg.tlsConfig != nil {
-		remote, err = (&tls.Dialer{Config: t.cfg.tlsConfig}).DialContext(ctx, "tcp", t.cfg.proxyHost)
+		cfg := t.cfg.tlsConfig.Clone()
+		cfg.NextProtos = []string{"http/1.1"}
+
+		remote, err = (&tls.Dialer{Config: cfg}).DialContext(ctx, "tcp", t.cfg.proxyHost)
 	} else {
 		remote, err = (&net.Dialer{}).DialContext(ctx, "tcp", t.cfg.proxyHost)
 	}


### PR DESCRIPTION
## Summary
Several changes:

- log the probe requests for debugging.
- disable redirects for the probe request, so we don't inadvertently get back the authenticate service's HTTP response
- disable http/2 and only support http/3 or http/1 (for https://github.com/pomerium/pomerium/issues/5431)
- force http/1 by adding it to the ALPN protocols for TLS connections

## Related issues
- [ENG-2131](https://linear.app/pomerium/issue/ENG-2131/cli-tcp-tunneling-only-works-with-http3)
- [ENG-2122](https://linear.app/pomerium/issue/ENG-2122/cli-tunnel-picker-should-not-follow-redirects)


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
