### PR TITLE
docs: fixed install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Pomerium Command Line Client (CLI) is a client-side helper application for [
 
 ## Installation
 
-Installation instructions are available in the [Pomerium Docs](https://www.pomerium.com/docs/releases.html#pomerium-cli).
+Installation instructions are available in the [Pomerium Docs](https://www.pomerium.com/docs/deploy/clients#install-pomerium-cli-and-desktop).
 
 ## Usage
 


### PR DESCRIPTION
## Summary

The installation link lead to a 404 page in the docs. This PR points to the correct instal link, https://www.pomerium.com/docs/deploy/clients#install-pomerium-cli-and-desktop, now.

## Related issues

Closes #507


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
