### PR TITLE
ci: exclude core from dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,3 +27,5 @@ updates:
       go:
         patterns:
           - "*"
+        exclude-patterns:
+          - "github.com/pomerium/pomerium"


### PR DESCRIPTION
## Summary

In general I think we want the `main` branch in this repo to track against the `main` branch in the pomerium/pomerium repo. Our release branch strategy can cause dependabot to propose upgrades that would undo this.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
