### PR TITLE
ENG-1026: update goreleaser to 2.8.2 and update configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.3.0
         with:
-          version: v1.18.2
+          version: v2.8.2
           args: release
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ build: ## Build everything.
 
 .PHONY: snapshot
 snapshot: ## Create release snapshot
-	APPARITOR_GITHUB_TOKEN=foo VERSION_FLAGS="$(CTIMEVAR)" goreleaser release --snapshot --rm-dist
+	APPARITOR_GITHUB_TOKEN=foo VERSION_FLAGS="$(CTIMEVAR)" goreleaser release --snapshot --clean
 
 
 .PHONY: help

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 project_name: pomerium-cli
 
 release:
@@ -41,19 +42,19 @@ builds:
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     id: pomerium-cli
-    builds:
+    ids:
       - pomerium-cli
     files:
       - none*
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
 
 checksum:
   disable: true
 
 snapshot:
-  name_template: "{{ .Version }}+next+{{ .ShortCommit }}"
+  version_template: "{{ .Version }}+next+{{ .ShortCommit }}"
 
 brews:
   - # Name template of the recipe
@@ -68,7 +69,7 @@ brews:
     # Default is 6 for all artifacts or each id if there a multiple versions.
     goarm: 6
 
-    tap:
+    repository:
       owner: pomerium
       name: homebrew-tap
       # Optionally a token can be provided, if it differs from the token provided to GoReleaser
@@ -80,14 +81,15 @@ brews:
       name: apparitor
       email: apparitor@users.noreply.github.com
 
-    folder: Formula
     install: |
       bin.install "pomerium-cli"
+
+    directory: Formula
 
 nfpms:
   - id: pomerium-cli
 
-    builds:
+    ids:
       - pomerium-cli
 
     package_name: pomerium-cli
@@ -106,16 +108,7 @@ nfpms:
 
     bindir: /usr/bin
 
-    overrides:
-      deb:
-        replacements:
-          arm64: arm64
-        file_name_template: '{{ .ProjectName }}_{{ .Version }}-{{ .Release }}_{{ .Arch }}{{ if .Arm }}{{if eq .Arm "7"}}hf{{ end }}{{ end }}'
-      rpm:
-        replacements:
-          arm64: aarch64
-          amd64: x86_64
-        file_name_template: '{{ .ProjectName }}-{{ .Version }}-{{ .Release }}.{{ .Arch }}{{ if .Arm }}{{if eq .Arm "7"}}hf{{ end }}{{ end }}'
+    file_name_template: "{{ .ConventionalFileName }}"
 
 dockers:
   - image_templates:


### PR DESCRIPTION
## Summary

Goreleaser 2 has been out for a while now, and is the default version available in homebrew.  

## Related issues

Part of ENG-1026

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [] ready for review
