### PR TITLE
ci: rework homebrew-tap updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,6 @@ jobs:
           args: release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          APPARITOR_GITHUB_TOKEN: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
           VERSION_FLAGS: ${{ needs.metadata.outputs.versionFlags }}
 
       - name: Compute checksums

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,7 +187,7 @@ jobs:
           docker manifest create -a pomerium/cli:latest pomerium/cli:amd64-${{ steps.tagName.outputs.tag }} pomerium/cli:arm64v8-${{ steps.tagName.outputs.tag }}
           docker manifest push pomerium/cli:latest
 
-  upload-checksums:
+  finish:
     runs-on: ubuntu-latest
     needs: [build-macos, build-windows, goreleaser]
     steps:
@@ -200,3 +200,17 @@ jobs:
           echo "${{ needs.build-windows.outputs.checksums }}" >> pomerium-cli_checksums.txt
           echo "${{ needs.goreleaser.outputs.checksums }}" >> pomerium-cli_checksums.txt
           gh release upload "${{ github.event.release.tag_name }}" pomerium-cli_checksums.txt
+
+      - id: clean_version
+        run: |
+          echo "release=${VERSION#v}" >> $GITHUB_OUTPUT
+        env:
+          VERSION: '${{ github.event.release.tag_name }}'
+
+      - name: Update homebrew tap
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0
+        with:
+          repository: pomerium/homebrew-tap
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+          event-type: pomerium-cli-release
+          client-payload: '{ "version": "${{ steps.clean_version.outputs.release }}" }'

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -55,35 +55,6 @@ checksum:
 snapshot:
   name_template: "{{ .Version }}+next+{{ .ShortCommit }}"
 
-brews:
-  - # Name template of the recipe
-    name: pomerium-cli
-
-    # IDs of the archives to use.
-    ids:
-      - pomerium-cli
-
-    # GOARM to specify which 32-bit arm version to use if there are multiple versions
-    # from the build section. Brew formulas support atm only one 32-bit version.
-    # Default is 6 for all artifacts or each id if there a multiple versions.
-    goarm: 6
-
-    tap:
-      owner: pomerium
-      name: homebrew-tap
-      # Optionally a token can be provided, if it differs from the token provided to GoReleaser
-      token: "{{ .Env.APPARITOR_GITHUB_TOKEN }}"
-
-    # Git author used to commit to the repository.
-    # Defaults are shown.
-    commit_author:
-      name: apparitor
-      email: apparitor@users.noreply.github.com
-
-    folder: Formula
-    install: |
-      bin.install "pomerium-cli"
-
 nfpms:
   - id: pomerium-cli
 


### PR DESCRIPTION
## Summary

The macOS and Windows binaries are currently built separately from GoReleaser (in order to be able to build against OS-native libraries using cgo). As a result, GoReleaser builds only the Linux binaries, and so it will update the Homebrew tap to be Linux-only.

Remove the `brews` section from the GoReleaser configuration, and instead trigger the replacement [`repository_dispatch` workflow](https://github.com/pomerium/homebrew-tap/blob/master/.github/workflows/cli.yaml) in the pomerium/homebrew-tap repo.

## Related issues

https://linear.app/pomerium/issue/ENG-1028/fix-homebrew-tap-automation

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
