### PR TITLE
Move mac builds to internal repo so they can be properly signed and notarized

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,39 +27,6 @@ jobs:
           )
           echo "versionFlags=${ldflags[*]}" >> $GITHUB_OUTPUT
 
-  build-macos:
-    runs-on: macos-latest
-    needs: metadata
-    outputs:
-      checksums: ${{ steps.build.outputs.checksums }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - name: Set up Go
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
-        with:
-          go-version: 1.24.x
-
-      - name: Build and archive
-        id: build
-        run: |
-          echo 'checksums<<EOF' >> $GITHUB_OUTPUT
-          for arch in amd64 arm64; do
-            mkdir -p bin/$arch
-            GOARCH=$arch CGO_ENABLED=1 go build -o bin/$arch \
-              -ldflags="-s -w ${{ needs.metadata.outputs.versionFlags }}" \
-              ./cmd/pomerium-cli
-            gtar czf pomerium-cli-darwin-$arch.tar.gz -C bin/$arch pomerium-cli
-            shasum -a 256 pomerium-cli-darwin-$arch.tar.gz >> $GITHUB_OUTPUT
-          done
-          echo EOF >> $GITHUB_OUTPUT
-
-      - name: Upload to release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" pomerium-cli-darwin-*.tar.gz
-
   build-windows:
     runs-on: windows-latest
     needs: metadata
@@ -207,10 +174,10 @@ jobs:
         env:
           VERSION: '${{ github.event.release.tag_name }}'
 
-      - name: Update homebrew tap
+      - name: trigger mac signed and notarized builds
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0
         with:
-          repository: pomerium/homebrew-tap
+          repository: pomerium/mac-builds
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
           event-type: pomerium-cli-release
-          client-payload: '{ "version": "${{ steps.clean_version.outputs.release }}" }'
+          client-payload: '{ "release": "${{ github.event.release.tag_name }}", "version_flags": "${{ needs.metadata.outputs.versionFlags }}", "push": "true" }'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,14 +156,13 @@ jobs:
 
   finish:
     runs-on: ubuntu-latest
-    needs: [build-macos, build-windows, goreleaser]
+    needs: [build-windows, goreleaser]
     steps:
       - name: Upload checksums
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "${{ needs.build-macos.outputs.checksums }}" >> pomerium-cli_checksums.txt
           echo "${{ needs.build-windows.outputs.checksums }}" >> pomerium-cli_checksums.txt
           echo "${{ needs.goreleaser.outputs.checksums }}" >> pomerium-cli_checksums.txt
           gh release upload "${{ github.event.release.tag_name }}" pomerium-cli_checksums.txt


### PR DESCRIPTION


## Summary

Signing and notarizing binaries for distribution outside of the apple app stores involves using developer ID private key material that's precious.  To avoid accidents and potentially signing rogue software or worse, this moves the build to a private repo. 

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
