### PR TITLE
update name template to avoid collisions with armhf and future proof against amd64 v2

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -78,7 +78,11 @@ nfpms:
 
     bindir: /usr/bin
 
-    file_name_template: "{{ .ConventionalFileName }}"
+    file_name_template: >-
+      {{- trimsuffix .ConventionalFileName .ConventionalExtension -}}
+      {{- if and (eq .Arm "6") (eq .ConventionalExtension ".deb") }}6{{ end -}}
+      {{- if not (eq .Amd64 "v1")}}{{ .Amd64 }}{{ end -}}
+      {{- .ConventionalExtension -}}
 
 dockers:
   - image_templates:


### PR DESCRIPTION
## Summary

debian uses the same suffix for arm6 and 7 

Similarly amd64/v2 gets the same suffix as v1.  

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
