### PR TITLE
Fix prerelease version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,6 +121,7 @@ jobs:
           TAG=$(git describe --tags --exact-match)
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          echo "pkgversion=$(echo  ${TAG#v} | tr '-' '~')"
 
       - name: Install Cloudsmith CLI
         run: |
@@ -131,7 +132,7 @@ jobs:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         working-directory: dist/
         run: |
-          VERSION=${{ steps.tagName.outputs.version }}
+          VERSION=${{ steps.tagName.outputs.pkgversion }}
           RPMS="pomerium-cli-${VERSION}-1.aarch64.rpm pomerium-cli-${VERSION}-1.x86_64.rpm pomerium-cli-${VERSION}-1.armhf.rpm"
           for pkg in $(echo $RPMS); do
             cloudsmith push rpm pomerium/pomerium/el/any-version $pkg

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,7 +121,7 @@ jobs:
           TAG=$(git describe --tags --exact-match)
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-          echo "pkgversion=$(echo  ${TAG#v} | tr '-' '~')"
+          echo "pkgversion=$(echo  ${TAG#v} | tr '-' '~')" >> $GITHUB_OUTPUT
 
       - name: Install Cloudsmith CLI
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,7 +133,7 @@ jobs:
         working-directory: dist/
         run: |
           VERSION=${{ steps.tagName.outputs.pkgversion }}
-          RPMS="pomerium-cli-${VERSION}-1.aarch64.rpm pomerium-cli-${VERSION}-1.x86_64.rpm pomerium-cli-${VERSION}-1.armhf.rpm"
+          RPMS="pomerium-cli-${VERSION}-1.aarch64.rpm pomerium-cli-${VERSION}-1.x86_64.rpm pomerium-cli-${VERSION}-1.armv6hl.rpm pomerium-cli-${VERSION}-1.armv7hl.rpm"
           for pkg in $(echo $RPMS); do
             cloudsmith push rpm pomerium/pomerium/el/any-version $pkg
           done


### PR DESCRIPTION
goreleaser changes prerelease version string for debs and rpms to mean the correct thing.

a tilde (~) in an rpm/deb package indicates to the package manager that it should be ranked lower than the unadorned version.

e.g. 0.29.2~rc1 < 0.29.2

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
