### PR TITLE
standardize cached credential file permissions

### DIFF
--- a/cmd/pomerium-cli/cache.go
+++ b/cmd/pomerium-cli/cache.go
@@ -129,7 +129,7 @@ func saveCachedCredential(serverURL string, creds *ExecCredential) error {
 		return fmt.Errorf("failed to create cache directory: %w", err)
 	}
 
-	f, err := os.Create(fn)
+	f, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create cache file: %w", err)
 	}


### PR DESCRIPTION
## Summary

Update the permissions for cached k8s ExecCredentials to match the permissions for cached JWTs.

## Related issues

https://linear.app/pomerium/issue/ENG-2205/

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
