### PR TITLE
switch from pomerium.io to pomerium.com

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
             "-X github.com/pomerium/cli/version.GitCommit=$(git rev-parse --short HEAD)"
             "-X github.com/pomerium/cli/version.BuildMeta=$(date +%s)"
             "-X github.com/pomerium/cli/version.ProjectName=pomerium-cli"
-            "-X github.com/pomerium/cli/version.ProjectURL=https://www.pomerium.io"
+            "-X github.com/pomerium/cli/version.ProjectURL=https://www.pomerium.com"
           )
           echo "versionFlags=${ldflags[*]}" >> $GITHUB_OUTPUT
 

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -98,7 +98,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--label=repository=http://github.com/pomerium/cli"
-      - "--label=homepage=http://www.pomerium.io"
+      - "--label=homepage=https://www.pomerium.com"
 
   - goarch: arm64
     image_templates:
@@ -114,7 +114,7 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--label=repository=http://github.com/pomerium/cli"
-      - "--label=homepage=http://www.pomerium.io"
+      - "--label=homepage=https://www.pomerium.com"
 
 docker_manifests:
   - name_template: "pomerium/cli:{{ .Tag }}"


### PR DESCRIPTION
## Summary

Update the version.ProjectURL flag and the docker 'homepage' labels to use the pomerium.com domain rather than pomerium.io.

## Related issues

https://linear.app/pomerium/issue/ENG-2589/standardize-on-pomeriumcom-for-websitedocs-urls

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
