### PR TITLE
ci: do not include deb/rpm packages in docker image

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
 FROM gcr.io/distroless/static:latest@sha256:b7b9a6953e7bed6baaf37329331051d7bdc1b99c885f6dbeb72d75b1baad54f9
 WORKDIR /pomerium
-COPY pomerium* /bin/
+COPY pomerium-cli /bin/
 ENTRYPOINT [ "/bin/pomerium-cli" ]


### PR DESCRIPTION
## Summary

The release Dockerfile copies all assets built by GoReleaser into the docker image. Besides the binary itself, this includes the .deb and .rpm packages. Instead, let's copy only the release binary.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
