### PR TITLE
[codex] docker: add explicit cli debug images

### DIFF
--- a/.github/debug-image-packages.txt
+++ b/.github/debug-image-packages.txt
@@ -1,0 +1,11 @@
+bash
+ca-certificates
+curl
+dnsutils
+iproute2
+iputils-ping
+jq
+lsof
+netcat-openbsd
+openssl
+procps

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -37,6 +37,20 @@ jobs:
             type=sha,priority=1000
             type=ref,event=branch
 
+      - name: docker meta debug
+        id: meta-debug
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: pomerium/cli
+          flavor: |
+            prefix=debug-
+          tags: |
+            type=sha,priority=1000
+            type=ref,event=branch
+
+      - name: Check Debug Image Contract
+        run: ./scripts/check-debug-image-contract
+
       - name: Docker Publish - Main
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
@@ -46,3 +60,13 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Docker Publish - Debug
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: .
+          file: ./Dockerfile.debug
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta-debug.outputs.tags }}
+          labels: ${{ steps.meta-debug.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,10 +124,12 @@ jobs:
           echo "pkgversion=$(echo  ${TAG#v} | tr '-' '~')" >> $GITHUB_OUTPUT
 
       - name: Install Cloudsmith CLI
+        if: "!contains(steps.tagName.outputs.tag, '-rc')"
         run: |
           pip3 install cloudsmith-cli
 
       - name: Publish to Cloudsmith
+        if: "!contains(steps.tagName.outputs.tag, '-rc')"
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         working-directory: dist/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,7 +177,6 @@ jobs:
           VERSION: "${{ github.event.release.tag_name }}"
 
       - name: trigger mac signed and notarized builds
-        if: "!github.event.release.prerelease"
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
         with:
           repository: pomerium/mac-builds

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,6 +82,9 @@ jobs:
         with:
           fetch-depth: 0 # GoReleaser needs commit history for changelog
 
+      - name: Check Debug Image Contract
+        run: ./scripts/check-debug-image-contract
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
@@ -156,6 +159,9 @@ jobs:
         run: |
           docker manifest create -a pomerium/cli:latest pomerium/cli:amd64-${{ steps.tagName.outputs.tag }} pomerium/cli:arm64v8-${{ steps.tagName.outputs.tag }}
           docker manifest push pomerium/cli:latest
+
+          docker manifest create -a pomerium/cli:debug-latest pomerium/cli:debug-amd64-${{ steps.tagName.outputs.tag }} pomerium/cli:debug-arm64v8-${{ steps.tagName.outputs.tag }}
+          docker manifest push pomerium/cli:debug-latest
 
   finish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,12 +124,12 @@ jobs:
           echo "pkgversion=$(echo  ${TAG#v} | tr '-' '~')" >> $GITHUB_OUTPUT
 
       - name: Install Cloudsmith CLI
-        if: "!contains(steps.tagName.outputs.tag, '-rc')"
+        if: "!github.event.release.prerelease"
         run: |
           pip3 install cloudsmith-cli
 
       - name: Publish to Cloudsmith
-        if: "!contains(steps.tagName.outputs.tag, '-rc')"
+        if: "!github.event.release.prerelease"
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         working-directory: dist/
@@ -177,6 +177,7 @@ jobs:
           VERSION: "${{ github.event.release.tag_name }}"
 
       - name: trigger mac signed and notarized builds
+        if: "!github.event.release.prerelease"
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
         with:
           repository: pomerium/mac-builds

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,8 @@ jobs:
           restore-keys: ${{ runner.os }}-go-bin
       - name: test
         run: make test
+      - name: check debug image contract
+        run: ./scripts/check-debug-image-contract
 
   precommit:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 # build
 RUN make build
 
-FROM gcr.io/distroless/base-debian12:debug@sha256:1f8759794cab46f0673e14afc03e3623cbd803b683abf7e3143fd041cc2e89f7
+FROM gcr.io/distroless/static:latest@sha256:47b2d72ff90843eb8a768b5c2f89b40741843b639d065b9b937b07cd59b479c6
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/cli/bin/* /bin/
 ENTRYPOINT [ "/bin/pomerium-cli" ]

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,20 @@
+FROM golang:1.26.2-bookworm@sha256:4f4ab2c90005e7e63cb631f0b4427f05422f241622ee3ec4727cc5febbf83e34 AS build
+WORKDIR /go/src/github.com/pomerium/cli
+
+# cache dependency downloads
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+# build
+RUN make build
+
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
+ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /pomerium
+COPY .github/debug-image-packages.txt /tmp/debug-image-packages.txt
+COPY scripts/install-debug-tools.sh /usr/local/bin/install-debug-tools
+RUN chmod 0755 /usr/local/bin/install-debug-tools \
+    && /usr/local/bin/install-debug-tools /tmp/debug-image-packages.txt
+COPY --from=build /go/src/github.com/pomerium/cli/bin/pomerium-cli /bin/pomerium-cli
+ENTRYPOINT [ "/bin/pomerium-cli" ]

--- a/Dockerfile.release.debug
+++ b/Dockerfile.release.debug
@@ -1,0 +1,9 @@
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
+ARG DEBIAN_FRONTEND=noninteractive
+WORKDIR /pomerium
+COPY .github/debug-image-packages.txt /tmp/debug-image-packages.txt
+COPY scripts/install-debug-tools.sh /usr/local/bin/install-debug-tools
+RUN chmod 0755 /usr/local/bin/install-debug-tools \
+    && /usr/local/bin/install-debug-tools /tmp/debug-image-packages.txt
+COPY pomerium-cli /bin/pomerium-cli
+ENTRYPOINT [ "/bin/pomerium-cli" ]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ The Pomerium Command Line Client (CLI) is a client-side helper application for [
 
 Installation instructions are available in the [Pomerium Docs](https://www.pomerium.com/docs/deploy/clients#install-pomerium-cli-and-desktop).
 
+## Container Images
+
+Published runtime container tags keep the existing tag names.
+
+Published debug container tags use the `debug-<tag>` form. The branch publish flow emits `debug-main` and `debug-sha-*` siblings, and releases emit `debug-v<version>` plus `debug-latest` for the latest stable release.
+
+CLI debug images use `debian:bookworm-slim` and preinstall a baseline troubleshooting toolbox:
+
+- `bash`
+- `ca-certificates`
+- `curl`
+- `dig`, `host`, and `nslookup`
+- `ip`, `ping`, and `ss`
+- `jq`
+- `lsof`
+- `nc`
+- `openssl`
+- `ps`
+
 ## Usage
 
 The two CLI operations are:

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -100,10 +100,47 @@ dockers:
       - "--label=repository=http://github.com/pomerium/cli"
       - "--label=homepage=https://www.pomerium.com"
 
+  - image_templates:
+      - "pomerium/cli:debug-amd64-{{ .Tag }}"
+    dockerfile: Dockerfile.release.debug
+    extra_files:
+      - .github/debug-image-packages.txt
+      - scripts/install-debug-tools.sh
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=repository=http://github.com/pomerium/cli"
+      - "--label=homepage=https://www.pomerium.com"
+
   - goarch: arm64
     image_templates:
       - "pomerium/cli:arm64v8-{{ .Tag }}"
     dockerfile: Dockerfile.release
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=repository=http://github.com/pomerium/cli"
+      - "--label=homepage=https://www.pomerium.com"
+
+  - goarch: arm64
+    image_templates:
+      - "pomerium/cli:debug-arm64v8-{{ .Tag }}"
+    dockerfile: Dockerfile.release.debug
+    extra_files:
+      - .github/debug-image-packages.txt
+      - scripts/install-debug-tools.sh
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -121,3 +158,8 @@ docker_manifests:
     image_templates:
       - pomerium/cli:arm64v8-{{ .Tag }}
       - pomerium/cli:amd64-{{ .Tag }}
+
+  - name_template: "pomerium/cli:debug-{{ .Tag }}"
+    image_templates:
+      - pomerium/cli:debug-arm64v8-{{ .Tag }}
+      - pomerium/cli:debug-amd64-{{ .Tag }}

--- a/scripts/check-debug-image-contract
+++ b/scripts/check-debug-image-contract
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -euo pipefail
+
+project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
+packages_file="${project_root}/.github/debug-image-packages.txt"
+runtime_dockerfile="${project_root}/Dockerfile"
+debug_dockerfile="${project_root}/Dockerfile.debug"
+release_runtime_dockerfile="${project_root}/Dockerfile.release"
+release_debug_dockerfile="${project_root}/Dockerfile.release.debug"
+install_debug_tools="${project_root}/scripts/install-debug-tools.sh"
+docker_main_workflow="${project_root}/.github/workflows/docker-main.yaml"
+release_workflow="${project_root}/.github/workflows/release.yaml"
+test_workflow="${project_root}/.github/workflows/test.yaml"
+goreleaser_config="${project_root}/goreleaser.yaml"
+
+require_file() {
+    local file="${1:?file is required}"
+
+    if [[ ! -f "$file" ]]; then
+        echo "missing file: ${file}" >&2
+        exit 1
+    fi
+}
+
+require_contains() {
+    local file="${1:?file is required}"
+    local expected="${2:?expected text is required}"
+
+    if ! grep -Fq "$expected" "$file"; then
+        echo "missing text in ${file}: ${expected}" >&2
+        exit 1
+    fi
+}
+
+require_line() {
+    local file="${1:?file is required}"
+    local expected="${2:?expected text is required}"
+
+    if ! grep -Fqx "$expected" "$file"; then
+        echo "missing line in ${file}: ${expected}" >&2
+        exit 1
+    fi
+}
+
+for file in \
+    "$packages_file" \
+    "$runtime_dockerfile" \
+    "$debug_dockerfile" \
+    "$release_runtime_dockerfile" \
+    "$release_debug_dockerfile" \
+    "$install_debug_tools" \
+    "$docker_main_workflow" \
+    "$release_workflow" \
+    "$test_workflow" \
+    "$goreleaser_config"; do
+    require_file "$file"
+done
+
+debug_base_line="$(grep -F "FROM debian:bookworm-slim@sha256:" "$debug_dockerfile")"
+
+echo "checking shared debug package list"
+required_packages=()
+while IFS= read -r package; do
+    required_packages+=("$package")
+done < "$packages_file"
+if [[ "${#required_packages[@]}" -eq 0 ]]; then
+    echo "empty package list: ${packages_file}" >&2
+    exit 1
+fi
+for package in "${required_packages[@]}"; do
+    require_line "$packages_file" "$package"
+done
+
+echo "checking runtime image definitions"
+require_contains "$runtime_dockerfile" "FROM gcr.io/distroless/static:latest@sha256:47b2d72ff90843eb8a768b5c2f89b40741843b639d065b9b937b07cd59b479c6"
+require_contains "$release_runtime_dockerfile" "FROM gcr.io/distroless/static:latest@sha256:47b2d72ff90843eb8a768b5c2f89b40741843b639d065b9b937b07cd59b479c6"
+
+echo "checking debug image definitions"
+for file in "$debug_dockerfile" "$release_debug_dockerfile"; do
+    require_contains "$file" "$debug_base_line"
+    require_contains "$file" "COPY .github/debug-image-packages.txt /tmp/debug-image-packages.txt"
+    require_contains "$file" "COPY scripts/install-debug-tools.sh /usr/local/bin/install-debug-tools"
+    require_contains "$file" "/usr/local/bin/install-debug-tools /tmp/debug-image-packages.txt"
+done
+
+echo "checking branch workflow coverage"
+require_contains "$docker_main_workflow" "platforms: linux/amd64,linux/arm64"
+require_contains "$docker_main_workflow" "./scripts/check-debug-image-contract"
+require_contains "$docker_main_workflow" "file: ./Dockerfile"
+require_contains "$docker_main_workflow" "file: ./Dockerfile.debug"
+require_contains "$docker_main_workflow" "prefix=debug-"
+
+echo "checking release workflow coverage"
+require_contains "$release_workflow" "./scripts/check-debug-image-contract"
+require_contains "$release_workflow" "docker manifest create -a pomerium/cli:debug-latest"
+require_contains "$release_workflow" "docker manifest push pomerium/cli:debug-latest"
+
+echo "checking release publish configuration"
+for image in \
+    "pomerium/cli:debug-amd64-{{ .Tag }}" \
+    "pomerium/cli:debug-arm64v8-{{ .Tag }}" \
+    'name_template: "pomerium/cli:debug-{{ .Tag }}"' \
+    ".github/debug-image-packages.txt" \
+    "scripts/install-debug-tools.sh"; do
+    require_contains "$goreleaser_config" "$image"
+done
+
+echo "checking pr validation coverage"
+require_contains "$test_workflow" "./scripts/check-debug-image-contract"
+
+echo "debug image contract checks passed"

--- a/scripts/install-debug-tools.sh
+++ b/scripts/install-debug-tools.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+packages_file="${1:?packages file is required}"
+
+apt-get update
+xargs -r -a "$packages_file" apt-get install -y --no-install-recommends
+apt-get clean
+rm -rf /var/lib/apt/lists/* "$packages_file"


### PR DESCRIPTION
## Summary

Separate runtime and debug container outputs in `pomerium/cli`: keep the existing runtime tags on the runtime image, add `debug-<tag>` siblings on `debian:bookworm-slim`, and validate the contract in CI and release config.

## Related issues

- https://linear.app/pomerium/issue/ENG-3886/cli-apply-the-published-debug-image-contract
- https://linear.app/pomerium/issue/ENG-3884/docker-make-published-debug-images-consistent-and-ship-a-baseline

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review

## Validation

- PASS: `shellcheck scripts/check-debug-image-contract scripts/install-debug-tools.sh`
- PASS: `./scripts/check-debug-image-contract`
- PASS: `goreleaser check --config goreleaser.yaml`
- PASS: `make build`
- PASS: `make test`
- FAIL: `make lint` in unchanged `third_party/ecpsigner/darwin/keychain/keychain.go` with existing `revive` / `unconvert` findings

## Notes

- Linux builds already export `CGO_ENABLED=0` in the Makefile, so the move to distroless `static` for runtime branch images stays consistent with release packaging.
- Claude review feedback was adopted for the install helper cleanup and contract-script maintenance reduction.

## AI assistance disclosure

Codex drafted the Dockerfile, workflow, script, and README changes, then I manually reviewed the diff and reran the validation commands above.