### PR TITLE
cli: remove fresh token validation, use healthz endpoint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,8 @@ linters:
           - gosec
         # G120 is not reliable
         text: G112|G120|G304|G703|G704|G705
+    paths:
+      - third_party
   settings:
     errcheck:
       exclude-functions:

--- a/authclient/authclient.go
+++ b/authclient/authclient.go
@@ -32,7 +32,7 @@ func New(options ...Option) *AuthClient {
 func (client *AuthClient) CheckBearerToken(ctx context.Context, serverURL *url.URL, bearerToken string) error {
 	browserURL := getBrowserURL(serverURL)
 	dst := browserURL.ResolveReference(&url.URL{
-		Path: "/livez",
+		Path: "/healthz",
 	})
 
 	req, err := http.NewRequest("GET", dst.String(), nil)

--- a/cmd/pomerium-cli/auth.go
+++ b/cmd/pomerium-cli/auth.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -112,25 +111,10 @@ func (r authCommandRunner) run(ctx context.Context, rawServerURL string) (string
 	if err != nil {
 		return "", fmt.Errorf("error retrieving JWT: %w", err)
 	}
-	if err := validateRawJWT(rawJWT); err != nil {
-		return "", fmt.Errorf("error validating JWT: %w", err)
-	}
 
 	if err := cache.StoreJWT(cacheKey, rawJWT); err != nil {
 		return "", fmt.Errorf("error storing JWT: %w", err)
 	}
 
 	return rawJWT, nil
-}
-
-func validateRawJWT(rawJWT string) error {
-	// Keep token parsing consistent with the existing CLI auth flows.
-	creds, err := parseToken(rawJWT)
-	if err != nil {
-		return err
-	}
-	if expiresAt := creds.Status.ExpirationTimestamp; !expiresAt.IsZero() && expiresAt.Before(time.Now()) {
-		return jwt.ErrExpired
-	}
-	return nil
 }

--- a/cmd/pomerium-cli/auth_test.go
+++ b/cmd/pomerium-cli/auth_test.go
@@ -185,29 +185,6 @@ func TestAuthCommandRunner(t *testing.T) {
 		require.Error(t, err)
 		assert.EqualError(t, err, "bad tls config")
 	})
-
-	t.Run("invalid fresh token returns error", func(t *testing.T) {
-		t.Parallel()
-
-		cache := jwt.NewMemoryCache()
-		authClient := &fakeAuthTokenClient{getJWT: "invalid"}
-		runner := authCommandRunner{
-			deps: authCommandDeps{
-				cacheLastURL: func(string) {},
-				getCache:     func() jwt.Cache { return cache },
-				getTLSConfig: func() (*tls.Config, error) { return nil, nil },
-				newAuthClient: func(*tls.Config) authTokenClient {
-					return authClient
-				},
-			},
-		}
-
-		_, err := runner.run(context.Background(), "http://route.example.com")
-		require.Error(t, err)
-		assert.ErrorContains(t, err, "error validating JWT:")
-		_, err = cache.LoadJWT(jwt.CacheKeyForHost("route.example.com", nil))
-		assert.ErrorIs(t, err, jwt.ErrNotFound)
-	})
 }
 
 func TestAuthCommand(t *testing.T) {


### PR DESCRIPTION
## Summary
Switch from the `/livez` to the `/healthz` endpoint and remove token validation after receiving a fresh token in the `auth` command. Because of local/server time sync issues, we can't reliably know if a token is valid merely based on the expiration timestamp.

## Related issues
- [ENG-3899](https://linear.app/pomerium/issue/ENG-3899/pomerium-cli-auth-triggers-re-authentication-but-returns-an-expired)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
