### PR TITLE
ci: update latest release branch

### DIFF
--- a/.github/workflows/update-branch-dependencies.yaml
+++ b/.github/workflows/update-branch-dependencies.yaml
@@ -1,0 +1,49 @@
+name: Update Branch Dependencies
+run-name: Update ${{ inputs.branch }} Dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: The branch to run the script on
+        default: main
+        required: false
+        type: string
+
+jobs:
+  update-branch-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup ASDF
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
+
+      - name: Update Tools
+        run: ./scripts/update-dependencies tools
+
+      - name: Update Docker Dependencies
+        run: ./scripts/update-dependencies docker
+
+      - name: Update Pomerium Dependencies
+        if: ${{ inputs.branch == 'main' }}
+        run: ./scripts/update-dependencies pomerium
+
+      - name: Generate
+        run: make generate
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        with:
+          author: GitHub Actions <apparitor@users.noreply.github.com>
+          base: ${{ inputs.branch }}
+          body: "This PR updates dependencies not managed by dependabot."
+          branch: ci/update-${{ inputs.branch }}
+          commit-message: "ci: update dependencies"
+          delete-branch: true
+          labels: ci
+          title: "ci: update ${{ inputs.branch }} dependencies"
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -9,41 +9,27 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-
-      - name: Setup ASDF
-        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
-
-      - name: Update Tools
-        run: ./scripts/update-dependencies tools
-
-      - name: Update Docker Dependencies
-        run: ./scripts/update-dependencies docker
-
-      - name: Update Pomerium Dependencies
-        run: ./scripts/update-dependencies pomerium
-
-      - name: Generate
-        run: make generate
-
-      - name: Check for Changes
-        id: git-diff
-        run: |
-          git config --global user.email "apparitor@users.noreply.github.com"
-          git config --global user.name "GitHub Actions"
-          git add .
-          git diff --cached --exit-code || echo "changed=true" >> $GITHUB_OUTPUT
-
-      - name: Create Pull Request
-        if: ${{ steps.git-diff.outputs.changed }} == 'true'
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+      - name: Get Latest Release
+        uses: rez0n/actions-github-release@05fabbd6b2b3ce3383299555ea518faea69b736d
+        id: latest_release
         with:
-          author: GitHub Actions <apparitor@users.noreply.github.com>
-          body: "This PR updates dependencies not managed by dependabot."
-          branch: ci/update-core
-          commit-message: "ci: update dependencies"
-          delete-branch: true
-          labels: ci
-          title: "ci: update dependencies"
-          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          type: "stable"
+
+      - name: Get Latest Release Branch
+        id: latest_release_branch
+        run: |
+          latest_release_branch="$(echo ${{ steps.latest_release.outputs.release }} | sed -E 's/^v?([0-9]+)[.]([0-9]+)[.].*$/\1-\2-0/')"
+          echo "value=$latest_release_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Update Latest Release Dependencies
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+        with:
+          workflow: update-branch-dependencies.yaml
+          inputs: '{"branch":"${{ steps.latest_release_branch.outputs.value }}"}'
+
+      - name: Trigger Update Main Dependencies
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+        with:
+          workflow: update-branch-dependencies.yaml
+          inputs: '{"branch":"main"}'


### PR DESCRIPTION
## Summary
In addition to updating main, update the latest release branch. Same as https://github.com/pomerium/pomerium/pull/6524

## Related issues
- [ENG-4248](https://linear.app/pomerium/issue/ENG-4248/various-ci-update-tasks-should-also-update-release-branches)

**Checklist**:

- [x] add related issues
- [ ] updated unit tests
- [ ] `docs` label added if changes affect user experience.
- [x] ready for review
