### PR TITLE
tunnel: handle a 401 response

### DIFF
--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -175,7 +175,8 @@ func httpStatusCodeToError(statusCode int) error {
 	case http.StatusMovedPermanently,
 		http.StatusFound,
 		http.StatusTemporaryRedirect,
-		http.StatusPermanentRedirect:
+		http.StatusPermanentRedirect,
+		http.StatusUnauthorized:
 		return errUnauthenticated
 	case http.StatusForbidden:
 		return errUnauthorized

--- a/tunnel/tunnel_test.go
+++ b/tunnel/tunnel_test.go
@@ -110,3 +110,29 @@ func TestForceHTTP1(t *testing.T) {
 
 	assert.Equal(t, "HTTP/1.1", protocol)
 }
+
+func Test_httpStatusCodeToError(t *testing.T) {
+	cases := []struct {
+		code     int
+		expected error
+	}{
+		{http.StatusOK, nil},
+		{http.StatusServiceUnavailable, errUnavailable},
+		{http.StatusMovedPermanently, errUnauthenticated},
+		{http.StatusFound, errUnauthenticated},
+		{http.StatusTemporaryRedirect, errUnauthenticated},
+		{http.StatusPermanentRedirect, errUnauthenticated},
+		{http.StatusUnauthorized, errUnauthenticated},
+		{http.StatusForbidden, errUnauthorized},
+	}
+	for _, c := range cases {
+		t.Run(http.StatusText(c.code), func(t *testing.T) {
+			assert.Equal(t, c.expected, httpStatusCodeToError(c.code))
+		})
+	}
+
+	t.Run("unexpected", func(t *testing.T) {
+		err := httpStatusCodeToError(http.StatusNotImplemented)
+		assert.ErrorContains(t, err, "invalid http response code: 501")
+	})
+}


### PR DESCRIPTION
## Summary

In v0.33, Pomerium changed to return a 401 response if a session token was presented in an HTTP header and the session was expired or invalid. (This indicates the client is not a web browser, so it doesn't make sense to redirect to the IdP login page as the client will not be able to complete the login flow.) See https://github.com/pomerium/pomerium/pull/6289.

However, pomerium-cli currently _does_ expect to see an HTTP redirect, and does not recognize the 401 response as indicating that a new login is required. Update pomerium-cli to treat a 401 response the same as a redirect response.

## Related issues

- https://github.com/pomerium/pomerium/issues/6649

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
