### PR TITLE
chore: upgrade go to 1.27

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,6 @@ formatters:
   enable:
     - gci
     - gofumpt
-    - goimports
   settings:
     gci:
       sections:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golangci-lint 2.12.2
-golang 1.26.6
+golangci-lint 2.13.1
+golang 1.27.0

--- a/api/cert_info.go
+++ b/api/cert_info.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/golang/groupcache/lru"
-	"google.golang.org/protobuf/proto"
 
 	pb "github.com/pomerium/cli/proto"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -26,7 +25,7 @@ func withCertInfo(cache *lru.Cache, records []*pb.Record) []*pb.Record {
 }
 
 func certInfoError(message string) *pb.CertificateInfo {
-	return &pb.CertificateInfo{Error: proto.String(message)}
+	return &pb.CertificateInfo{Error: new(message)}
 }
 
 func getCertInfo(cache *lru.Cache, raw []byte) (*pb.CertificateInfo, error) {

--- a/api/config_server_test.go
+++ b/api/config_server_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/pomerium/cli/api"
 	pb "github.com/pomerium/cli/proto"
@@ -25,17 +24,17 @@ func TestUpsertLoadSave(t *testing.T) {
 			{
 				Tags: []string{"one"},
 				Conn: &pb.Connection{
-					Name:       proto.String("test one"),
+					Name:       new("test one"),
 					RemoteAddr: "test1.another.domain.com",
-					ListenAddr: proto.String(":9993"),
+					ListenAddr: new(":9993"),
 				},
 			},
 			{
 				Tags: []string{"one", "two"},
 				Conn: &pb.Connection{
-					Name:       proto.String("test two"),
+					Name:       new("test two"),
 					RemoteAddr: "test2.some.domain.com",
-					ListenAddr: proto.String(":9991"),
+					ListenAddr: new(":9991"),
 				},
 			},
 		} {
@@ -163,9 +162,9 @@ KSwExwUr94Fr+qoXl/okwJY=
 			r, err := cfg.Upsert(ctx, &pb.Record{
 				Tags: []string{"one"},
 				Conn: &pb.Connection{
-					Name:       proto.String("test one"),
+					Name:       new("test one"),
 					RemoteAddr: "test1.another.domain.com",
-					ListenAddr: proto.String(":9993"),
+					ListenAddr: new(":9993"),
 					ClientCert: crt,
 				},
 			})
@@ -221,17 +220,17 @@ func TestExportImport(t *testing.T) {
 		{
 			Tags: []string{"one"},
 			Conn: &pb.Connection{
-				Name:       proto.String("test one"),
+				Name:       new("test one"),
 				RemoteAddr: "test1.another.domain.com",
-				ListenAddr: proto.String(":9993"),
+				ListenAddr: new(":9993"),
 			},
 		},
 		{
 			Tags: []string{"one", "two"},
 			Conn: &pb.Connection{
-				Name:       proto.String("test two"),
+				Name:       new("test two"),
 				RemoteAddr: "test2.some.domain.com",
-				ListenAddr: proto.String(":9991"),
+				ListenAddr: new(":9991"),
 			},
 		},
 	}

--- a/api/config_test.go
+++ b/api/config_test.go
@@ -131,8 +131,3 @@ func (s *stubConfigProvider) Save(b []byte) error {
 	s.data = b
 	return nil
 }
-
-//go:fix inline
-func ptr[T any](value T) *T {
-	return new(value)
-}

--- a/api/config_test.go
+++ b/api/config_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	pb "github.com/pomerium/cli/proto"
 )
@@ -19,11 +18,11 @@ func TestConfig(t *testing.T) {
 	assert.Empty(t, cfg.listAll())
 
 	cfg.upsert(&pb.Record{
-		Id:   proto.String("a"),
+		Id:   new("a"),
 		Tags: []string{"alpha", "bravo"},
 	})
 	cfg.upsert(&pb.Record{
-		Id:   proto.String("b"),
+		Id:   new("b"),
 		Tags: []string{"go", "bravo"},
 	})
 	assert.Empty(t, cmp.Diff([]string{"alpha", "bravo", "go"},
@@ -55,7 +54,7 @@ func TestTags(t *testing.T) {
 		{"echo", "foxtrot"},
 	} {
 		cfg.upsert(&pb.Record{
-			Id:   proto.String("a"),
+			Id:   new("a"),
 			Tags: tags,
 		})
 		assert.Empty(t, cmp.Diff(tags, cfg.getTags(),
@@ -98,12 +97,12 @@ func TestLoadConfig(t *testing.T) {
 	assert.NoError(t, err)
 
 	exampleRecord := &pb.Record{
-		Id:   ptr("114acc22-c18f-4326-8606-425acc2b3eb5"),
+		Id:   new("114acc22-c18f-4326-8606-425acc2b3eb5"),
 		Tags: []string{"admin"},
 		Conn: &pb.Connection{
-			Name:       ptr("Example"),
+			Name:       new("Example"),
 			RemoteAddr: "example.route.pomerium.com:5000",
-			ListenAddr: ptr("127.0.0.1:5000"),
+			ListenAddr: new("127.0.0.1:5000"),
 			TlsOptions: &pb.Connection_DisableTlsVerification{},
 		},
 	}
@@ -133,6 +132,7 @@ func (s *stubConfigProvider) Save(b []byte) error {
 	return nil
 }
 
+//go:fix inline
 func ptr[T any](value T) *T {
-	return &value
+	return new(value)
 }

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	pb "github.com/pomerium/cli/proto"
@@ -31,7 +30,7 @@ func TestEventsBroadcast(t *testing.T) {
 				idx := fmt.Sprintf("id%d", id)
 				evt := &pb.ConnectionStatusUpdate{
 					Id:       idx,
-					PeerAddr: proto.String(fmt.Sprintf("localhost:999%d", peer)),
+					PeerAddr: new(fmt.Sprintf("localhost:999%d", peer)),
 					Status:   status,
 				}
 				expect[idx] = append(expect[idx], evt)

--- a/api/listener_server.go
+++ b/api/listener_server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/pomerium/cli/proto"
@@ -85,7 +84,7 @@ func (s *server) connectTCPTunnelLocked(id string, tun Tunnel, listenAddr string
 	if err != nil {
 		_ = s.EventBroadcaster.Update(ctx, &pb.ConnectionStatusUpdate{
 			Id:        id,
-			LastError: proto.String(fmt.Errorf("listen: %w", err).Error()),
+			LastError: new(fmt.Errorf("listen: %w", err).Error()),
 			Ts:        timestamppb.Now(),
 		})
 		cancel()
@@ -95,7 +94,7 @@ func (s *server) connectTCPTunnelLocked(id string, tun Tunnel, listenAddr string
 	if err = s.SetListening(id, cancel, li.Addr().String()); err != nil {
 		_ = s.EventBroadcaster.Update(ctx, &pb.ConnectionStatusUpdate{
 			Id:        id,
-			LastError: proto.String(fmt.Errorf("SetListening: %w", err).Error()),
+			LastError: new(fmt.Errorf("SetListening: %w", err).Error()),
 			Ts:        timestamppb.Now(),
 		})
 		cancel()
@@ -114,7 +113,7 @@ func (s *server) connectUDPTunnelLocked(id string, tun Tunnel, listenAddr string
 	if err != nil {
 		_ = s.EventBroadcaster.Update(ctx, &pb.ConnectionStatusUpdate{
 			Id:        id,
-			LastError: proto.String(fmt.Errorf("ResolveUDPAddr: %w", err).Error()),
+			LastError: new(fmt.Errorf("ResolveUDPAddr: %w", err).Error()),
 			Ts:        timestamppb.Now(),
 		})
 		cancel()
@@ -125,7 +124,7 @@ func (s *server) connectUDPTunnelLocked(id string, tun Tunnel, listenAddr string
 	if err != nil {
 		_ = s.EventBroadcaster.Update(ctx, &pb.ConnectionStatusUpdate{
 			Id:        id,
-			LastError: proto.String(fmt.Errorf("ListenUDP: %w", err).Error()),
+			LastError: new(fmt.Errorf("ListenUDP: %w", err).Error()),
 			Ts:        timestamppb.Now(),
 		})
 		cancel()

--- a/api/listener_server_test.go
+++ b/api/listener_server_test.go
@@ -1,22 +1,19 @@
 package api_test
 
 import (
-	"context"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/pomerium/cli/api"
 	pb "github.com/pomerium/cli/proto"
 )
 
 func TestListenerServer(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	srv, err := api.NewServer(ctx)
 	require.NoError(t, err)
@@ -25,7 +22,7 @@ func TestListenerServer(t *testing.T) {
 		Tags: []string{"test"},
 		Conn: &pb.Connection{
 			RemoteAddr: "tcp.localhost.pomerium.io:99",
-			ListenAddr: proto.String(":0"),
+			ListenAddr: new(":0"),
 		},
 	})
 	require.NoError(t, err)
@@ -105,8 +102,7 @@ func TestListenerServer(t *testing.T) {
 }
 
 func TestDeleteActiveListener(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	srv, err := api.NewServer(ctx)
 	require.NoError(t, err)
@@ -115,7 +111,7 @@ func TestDeleteActiveListener(t *testing.T) {
 		Tags: []string{"test"},
 		Conn: &pb.Connection{
 			RemoteAddr: "tcp.localhost.pomerium.io:99",
-			ListenAddr: proto.String(":0"),
+			ListenAddr: new(":0"),
 		},
 	})
 	require.NoError(t, err)
@@ -152,7 +148,7 @@ func TestDeleteActiveListener(t *testing.T) {
 		Tags: []string{"test"},
 		Conn: &pb.Connection{
 			RemoteAddr: "notactive.localhost.pomerium.io:99",
-			ListenAddr: proto.String(":0"),
+			ListenAddr: new(":0"),
 		},
 	})
 	require.NoError(t, err)

--- a/api/routes.go
+++ b/api/routes.go
@@ -3,8 +3,6 @@ package api
 import (
 	"context"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/pomerium/cli/internal/portal"
 	pb "github.com/pomerium/cli/proto"
 )
@@ -41,7 +39,7 @@ func (srv *server) FetchRoutes(
 			LogoUrl:     route.LogoURL,
 		}
 		if route.ConnectCommand != "" {
-			r.ConnectCommand = proto.String(route.ConnectCommand)
+			r.ConnectCommand = new(route.ConnectCommand)
 		}
 		res.Routes = append(res.Routes, r)
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -26,7 +26,7 @@ type ConfigProvider interface {
 	Save([]byte) error
 }
 
-type Config interface{}
+type Config any
 
 // ListenerStatus marks individual records as locked
 type ListenerStatus interface {

--- a/api/tunnel.go
+++ b/api/tunnel.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/pomerium/cli/proto"
@@ -130,7 +129,7 @@ type tunnelEvents struct {
 
 func (evt *tunnelEvents) withPeer(conn net.Conn) *tunnelEvents {
 	ne := *evt
-	ne.peer = proto.String(conn.RemoteAddr().String())
+	ne.peer = new(conn.RemoteAddr().String())
 	return &ne
 }
 

--- a/api/tunnel_test.go
+++ b/api/tunnel_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/proto"
 
 	pb "github.com/pomerium/cli/proto"
 )
@@ -44,7 +43,7 @@ func TestGetProxy(t *testing.T) {
 		"custom https proxy": {
 			&pb.Connection{
 				RemoteAddr:  "tcp.localhost.pomerium.io:99",
-				PomeriumUrl: proto.String("https://localhost"),
+				PomeriumUrl: new("https://localhost"),
 			},
 			"https://localhost:443",
 			false,
@@ -52,7 +51,7 @@ func TestGetProxy(t *testing.T) {
 		"custom http proxy": {
 			&pb.Connection{
 				RemoteAddr:  "tcp.localhost.pomerium.io:99",
-				PomeriumUrl: proto.String("http://localhost"),
+				PomeriumUrl: new("http://localhost"),
 			},
 			"http://localhost:80",
 			false,
@@ -60,7 +59,7 @@ func TestGetProxy(t *testing.T) {
 		"custom https proxy port": {
 			&pb.Connection{
 				RemoteAddr:  "tcp.localhost.pomerium.io:99",
-				PomeriumUrl: proto.String("https://localhost:5443"),
+				PomeriumUrl: new("https://localhost:5443"),
 			},
 			"https://localhost:5443",
 			false,
@@ -68,7 +67,7 @@ func TestGetProxy(t *testing.T) {
 		"custom http proxy port": {
 			&pb.Connection{
 				RemoteAddr:  "tcp.localhost.pomerium.io:99",
-				PomeriumUrl: proto.String("http://localhost:8080"),
+				PomeriumUrl: new("http://localhost:8080"),
 			},
 			"http://localhost:8080",
 			false,
@@ -76,7 +75,7 @@ func TestGetProxy(t *testing.T) {
 		"invalid url": {
 			&pb.Connection{
 				RemoteAddr:  "tcp.localhost.pomerium.io:99",
-				PomeriumUrl: proto.String("localhost:7777"),
+				PomeriumUrl: new("localhost:7777"),
 			},
 			"",
 			true,
@@ -84,7 +83,7 @@ func TestGetProxy(t *testing.T) {
 		"empty proxy url": {
 			&pb.Connection{
 				RemoteAddr:  "tcp.localhost.pomerium.io:99",
-				PomeriumUrl: proto.String(""),
+				PomeriumUrl: new(""),
 			},
 			"",
 			true,

--- a/cmd/pomerium-cli/kubernetes.go
+++ b/cmd/pomerium-cli/kubernetes.go
@@ -174,7 +174,7 @@ type ExecCredential struct {
 type ExecCredentialStatus struct {
 	// ExpirationTimestamp indicates a time when the provided credentials expire.
 	// +optional
-	ExpirationTimestamp time.Time `json:"expirationTimestamp,omitempty"`
+	ExpirationTimestamp time.Time `json:"expirationTimestamp"`
 	// Token is a bearer token used by the client for request authentication.
 	Token string `json:"token,omitempty"`
 	// PEM-encoded client TLS certificates (including intermediates, if any).

--- a/cmd/pomerium-cli/main.go
+++ b/cmd/pomerium-cli/main.go
@@ -61,7 +61,7 @@ func setupLogger() {
 	zerolog.DefaultContextLogger = &log.Logger
 }
 
-func fatalf(msg string, args ...interface{}) {
+func fatalf(msg string, args ...any) {
 	fmt.Fprintf(os.Stderr, msg+"\n", args...)
 	os.Exit(1)
 }

--- a/proto/log.go
+++ b/proto/log.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-func appendProto(evt *zerolog.Event, key string, obj interface{}) *zerolog.Event {
+func appendProto(evt *zerolog.Event, key string, obj any) *zerolog.Event {
 	if obj == nil {
 		return evt.Str(key, "nil")
 	}

--- a/tunnel/tunnel_http2.go
+++ b/tunnel/tunnel_http2.go
@@ -64,7 +64,7 @@ func (t *http2tunneler) TunnelTCP(
 
 	req := (&http.Request{
 		Method:        "CONNECT",
-		URL:           &url.URL{Opaque: t.cfg.dstHost},
+		URL:           &url.URL{Opaque: t.cfg.dstHost, Host: t.cfg.dstHost},
 		Host:          t.cfg.dstHost,
 		Header:        hdr,
 		Body:          pr,

--- a/tunnel/tunnel_http3.go
+++ b/tunnel/tunnel_http3.go
@@ -238,8 +238,7 @@ func (t *http3tunneler) readLocal(ctx context.Context, dst *http3.RequestStream,
 
 		err = dst.SendDatagram(datagram.data)
 
-		var tooLargeError *quic.DatagramTooLargeError
-		if errors.As(err, &tooLargeError) {
+		if tooLargeError, ok := errors.AsType[*quic.DatagramTooLargeError](err); ok {
 			logMaxDatagramPayloadSizeOnce.Do(func() {
 				log.Ctx(ctx).Error().
 					Int64("max-datagram-payload-size", tooLargeError.MaxDatagramPayloadSize).

--- a/tunnel/urls_test.go
+++ b/tunnel/urls_test.go
@@ -28,7 +28,6 @@ func TestParseURLs(t *testing.T) {
 		{"invalid pomerium url", "redis.example.com:6379", "example.com:1234", "", "", errors.New("invalid pomerium url")},
 		{"pomerium url", "redis.example.com:6379", "https://proxy.example.com", "redis.example.com:6379", "https://proxy.example.com:443", nil},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Summary
Upgrade go to 1.27. Also run `go fix`.

## Related issues
- [ENG-4338](https://linear.app/pomerium/issue/ENG-4338/various-upgrade-go-to-127)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
